### PR TITLE
feature/issue 2 - stage 2/ci baseline: fix reusable workflow shell

### DIFF
--- a/.github/workflows/python-job.yml
+++ b/.github/workflows/python-job.yml
@@ -13,7 +13,7 @@ on:
 
 defaults:
   run:
-    shell: bash -euo pipefail  # fail fast shell
+    shell: 'bash -euo pipefail {0}' # fail fast
 
 jobs:
   job:


### PR DESCRIPTION
use 'bash -euo pipefail {0}'