### PR TITLE
Feature/issue 16/full metadata ingest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ name = "image-recommender"
 version = "0.0.1"
 requires-python = ">=3.12"
 # runtime deps
-dependencies = ["numpy", "pillow"]
+dependencies = ["numpy", "pillow", "tqdm"]
 
 [project.optional-dependencies]
 # test deps

--- a/src/image_recommender/db/connector.py
+++ b/src/image_recommender/db/connector.py
@@ -1,4 +1,5 @@
 import sqlite3
+from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
 
 DB_PATH = "data/metadata.db"  # default path to the DB

--- a/src/image_recommender/db/connector.py
+++ b/src/image_recommender/db/connector.py
@@ -127,3 +127,11 @@ def iter_all_ids(db_path: str | None = None) -> Iterator[int]:
         cur = conn.execute("SELECT image_id FROM images")
         for row in cur:
             yield row[0]  # yield image_id
+
+
+def iter_all_paths(db_path=None):
+    """Iterate over all image paths in the database."""
+    with get_conn(db_path=db_path) as conn:
+        cur = conn.execute("SELECT path FROM images")
+        for row in cur:
+            yield row[0]  # yield path

--- a/src/image_recommender/db/connector.py
+++ b/src/image_recommender/db/connector.py
@@ -31,16 +31,22 @@ def init_db(db_path: str | None = None) -> None:
             conn.executescript(f.read())  # execute SQL script
 
 
-#  CRUD OPERATIONS (Create, Read, Update, Delete):
-
 # ---------- CREATE / UPDATE ----------
 
 
 def upsert_image(
-    path=str, width=None, height=None, ext=None, bytes_=None, added_at=None, db_path=None, conn=None
-):
+    path: str,
+    width: int | None = None,
+    height: int | None = None,
+    ext: str | None = None,
+    bytes_: int | None = None,
+    added_at: str | None = None,
+    db_path: str | None = None,
+    conn: sqlite3.Connection | None = None,
+) -> int:
     """
     Updates or inserts an image into the database.
+    Returns the image_id.
     """
     own_conn = conn is None
     with (
@@ -50,7 +56,6 @@ def upsert_image(
             """
             INSERT INTO images (path, width, height, ext, bytes, added_at)
             VALUES (?, ?, ?, ?, ?, ?)
-
             ON CONFLICT(path) DO UPDATE SET
                 width = excluded.width,
                 height = excluded.height,
@@ -60,8 +65,8 @@ def upsert_image(
             """,
             (path, width, height, ext, bytes_, added_at),
         )
-        cur = conn.execute("SELECT image_id FROM images WHERE path = ?", (path,))  # fetch image_id
-        return cur.fetchone()["image_id"]  # return image_id
+        cur = conn.execute("SELECT image_id FROM images WHERE path = ?", (path,))
+        return cur.fetchone()["image_id"]
 
 
 # ---------- READ ----------
@@ -73,7 +78,7 @@ def get_by_id(image_id: int, db_path: str | None = None) -> sqlite3.Row | None:
     """
     with get_conn(db_path=db_path) as conn:
         cur = conn.execute("SELECT * FROM images WHERE image_id = ?", (image_id,))
-        return cur.fetchone()  # return the image row (or None)
+        return cur.fetchone()
 
 
 def get_by_path(path: str, db_path: str | None = None) -> sqlite3.Row | None:
@@ -82,7 +87,7 @@ def get_by_path(path: str, db_path: str | None = None) -> sqlite3.Row | None:
     """
     with get_conn(db_path=db_path) as conn:
         cur = conn.execute("SELECT * FROM images WHERE path = ?", (path,))
-        return cur.fetchone()  # return the image row (or None)
+        return cur.fetchone()
 
 
 def get_path_by_id(image_id: int, db_path: str | None = None) -> str | None:
@@ -108,7 +113,7 @@ def delete_by_path(path: str, db_path: str | None = None) -> None:
         conn.execute("DELETE FROM images WHERE path = ?", (path,))
 
 
-# ---------- PERFORMANCE SANITY (Nice-to-have) ----------
+# ---------- PERFORMANCE SANITY ----------
 
 
 def count(db_path: str | None = None) -> int:
@@ -123,12 +128,12 @@ def iter_all_ids(db_path: str | None = None) -> Iterator[int]:
     with get_conn(db_path=db_path) as conn:
         cur = conn.execute("SELECT image_id FROM images")
         for row in cur:
-            yield row[0]  # yield image_id
+            yield row[0]
 
 
-def iter_all_paths(db_path=None):
+def iter_all_paths(db_path: str | None = None) -> Iterator[str]:
     """Iterate over all image paths in the database."""
     with get_conn(db_path=db_path) as conn:
         cur = conn.execute("SELECT path FROM images")
         for row in cur:
-            yield row[0]  # yield path
+            yield row[0]

--- a/src/image_recommender/db/connector.py
+++ b/src/image_recommender/db/connector.py
@@ -1,6 +1,5 @@
 import sqlite3
-from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 
 DB_PATH = "data/metadata.db"  # default path to the DB
 
@@ -37,18 +36,15 @@ def init_db(db_path: str | None = None) -> None:
 
 
 def upsert_image(
-    path: str,
-    width: int | None = None,
-    height: int | None = None,
-    ext: str | None = None,
-    bytes_: bytes | None = None,
-    added_at: str | None = None,
-    db_path: str | None = None,
+    path=str, width=None, height=None, ext=None, bytes_=None, added_at=None, db_path=None, conn=None
 ):
     """
     Updates or inserts an image into the database.
     """
-    with get_conn(db_path=db_path) as conn:
+    own_conn = conn is None
+    with (
+        get_conn(db_path=db_path) if own_conn else nullcontext(conn)
+    ) as conn:  # nullcontext: no-op context manager
         conn.execute(
             """
             INSERT INTO images (path, width, height, ext, bytes, added_at)

--- a/src/image_recommender/ingest_metadata.py
+++ b/src/image_recommender/ingest_metadata.py
@@ -1,0 +1,74 @@
+import argparse
+import datetime
+from pathlib import Path
+
+from PIL import Image, UnidentifiedImageError
+from tqdm import tqdm
+
+from image_recommender.db import connector
+
+
+def get_existing_paths(db_path=None):
+    """Loads all existing paths from DB."""
+    return set(connector.iter_all_paths(db_path=db_path))  # set of paths
+
+
+def scan_and_ingest_metadata(base_path: str, db_path=None):
+    """Scan images and ingest metadata."""
+    base_path = Path(base_path)  # ensure Path object
+    connector.init_db(db_path=db_path)  # initialize DB
+
+    existing_paths = get_existing_paths(db_path=db_path)
+
+    total_files = sum(1 for _ in base_path.rglob("*.*"))  # rglob: all files containing "." in path
+
+    print(f"Found {total_files} files to process in {base_path}")  # assumed amount of files
+
+    for path in tqdm(  # using tqdm for progress bar
+        base_path.rglob("*.*"),
+        total=total_files,
+        desc="Scanning images",
+        unit="img",
+        dynamic_ncols=True,
+        mininterval=0.1,  # update interval in seconds
+    ):
+
+        # ---------- INGEST / UPSERT METADATA LOGIC ----------
+
+        abs_path = str(path.resolve())  # absolute path as string
+
+        if abs_path in existing_paths:  # If path already exists in DB...
+            continue  # ...skip and go to next file.
+
+        try:
+            with Image.open(path) as img:  # read image information
+                width, height = img.size
+                bytes_ = path.stat().st_size
+                ext = path.suffix.lower()
+                added_at = datetime.datetime.now().isoformat()
+
+                connector.upsert_image(  # using upsert_image from connector.py
+                    abs_path, width, height, ext, bytes_, added_at, db_path=db_path
+                )
+
+        except (
+            UnidentifiedImageError,
+            OSError,
+        ):  # If image cannot be identified or other OS error...
+            continue  # ...skip it.
+
+    total_ingested = connector.count(db_path=db_path)
+    print(f"Total images ingested: {total_ingested}")  # final count of ingested images after scan
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Scan images and ingest metadata")
+    parser.add_argument("--root", required=True, help="Root folder with images")
+    parser.add_argument("--db", default=None, help="SQLite DB path")
+    args = parser.parse_args()
+
+    scan_and_ingest_metadata(args.root, db_path=args.db)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/image_recommender/ingest_metadata.py
+++ b/src/image_recommender/ingest_metadata.py
@@ -8,63 +8,62 @@ from tqdm import tqdm
 from image_recommender.db import connector
 
 
-def get_existing_paths(db_path=None):
+def get_existing_paths(db_path: str | None = None) -> set[str]:
     """Loads all existing paths from DB."""
-    return set(connector.iter_all_paths(db_path=db_path))  # set of paths
+    existing_paths: set[str] = set(connector.iter_all_paths(db_path=db_path))
+    return existing_paths
 
 
-def scan_and_ingest_metadata(base_path: str, db_path=None):
+def scan_and_ingest_metadata(base_path: str, db_path: str | None = None) -> None:
     """Scan images and ingest metadata."""
-    base_path = Path(base_path)  # ensure Path object
+    base_path_obj: Path = Path(base_path)  # ensure Path object
     connector.init_db(db_path=db_path)  # initialize DB
 
-    existing_paths = get_existing_paths(db_path=db_path)
+    existing_paths: set[str] = get_existing_paths(db_path=db_path)
 
-    files = list(base_path.rglob("*.*"))
-    total_files = len(files)
+    files: list[Path] = list(base_path_obj.rglob("*.*"))
+    total_files: int = len(files)
 
-    print(f"Found {total_files} files to process in {base_path}")  # assumed amount of files
+    print(f"Found {total_files} files to process in {base_path_obj}")  # assumed amount of files
 
-    with connector.get_conn(db_path=db_path) as conn:  # single DB connection
-        for path in tqdm(
-            files, total=total_files, desc="Scanning images", unit="img", dynamic_ncols=True
-        ):
+    for path in tqdm(
+        files, total=total_files, desc="Scanning images", unit="img", dynamic_ncols=True
+    ):
 
-            # ---------- INGEST / UPSERT METADATA LOGIC ----------
+        # ---------- INGEST / UPSERT METADATA LOGIC ----------
 
-            abs_path = str(path.resolve())
-            if abs_path in existing_paths:
-                continue
+        abs_path: str = str(path.resolve())
+        if abs_path in existing_paths:
+            continue
 
-            try:
-                with Image.open(path) as img:
-                    width, height = img.size
-                    bytes_ = path.stat().st_size
-                    ext = path.suffix.lower()
-                    added_at = datetime.datetime.now().isoformat()
+        try:
+            with Image.open(path) as img:
+                width, height = img.size
+                bytes_: int = path.stat().st_size
+                ext: str = path.suffix.lower()
+                added_at: str = datetime.datetime.now().isoformat()
 
-                    connector.upsert_image(
-                        abs_path, width, height, ext, bytes_, added_at, conn=conn
-                    )
+                # Pass db_path, not conn
+                connector.upsert_image(
+                    abs_path, width, height, ext, bytes_, added_at, db_path=db_path
+                )
 
-            except (
-                UnidentifiedImageError,
-                OSError,
-            ):  # If image cannot be identified or other OS error...
-                continue  # ...skip it.
+        except (UnidentifiedImageError, OSError):
+            continue  # ...skip it.
 
-    print(
-        f"Total images ingested: {connector.count(db_path=db_path)}"
-    )  # final count of ingested images after scan
+    total_ingested: int = connector.count(db_path=db_path)
+    print(f"Total images ingested: {total_ingested}")  # final count of ingested images after scan
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Scan images and ingest metadata")
+def main() -> None:
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
+        description="Scan images and ingest metadata"
+    )
     parser.add_argument("--root", required=True, help="Root folder with images")
     parser.add_argument("--db", default=None, help="SQLite DB path")
-    args = parser.parse_args()
+    args: argparse.Namespace = parser.parse_args()
 
-    scan_and_ingest_metadata(args.root, db_path=args.db)
+    scan_and_ingest_metadata(base_path=args.root, db_path=args.db)
 
 
 if __name__ == "__main__":

--- a/src/image_recommender/ingest_metadata.py
+++ b/src/image_recommender/ingest_metadata.py
@@ -20,45 +20,42 @@ def scan_and_ingest_metadata(base_path: str, db_path=None):
 
     existing_paths = get_existing_paths(db_path=db_path)
 
-    total_files = sum(1 for _ in base_path.rglob("*.*"))  # rglob: all files containing "." in path
+    files = list(base_path.rglob("*.*"))
+    total_files = len(files)
 
     print(f"Found {total_files} files to process in {base_path}")  # assumed amount of files
 
-    for path in tqdm(  # using tqdm for progress bar
-        base_path.rglob("*.*"),
-        total=total_files,
-        desc="Scanning images",
-        unit="img",
-        dynamic_ncols=True,
-        mininterval=0.1,  # update interval in seconds
-    ):
+    with connector.get_conn(db_path=db_path) as conn:  # single DB connection
+        for path in tqdm(
+            files, total=total_files, desc="Scanning images", unit="img", dynamic_ncols=True
+        ):
 
-        # ---------- INGEST / UPSERT METADATA LOGIC ----------
+            # ---------- INGEST / UPSERT METADATA LOGIC ----------
 
-        abs_path = str(path.resolve())  # absolute path as string
+            abs_path = str(path.resolve())
+            if abs_path in existing_paths:
+                continue
 
-        if abs_path in existing_paths:  # If path already exists in DB...
-            continue  # ...skip and go to next file.
+            try:
+                with Image.open(path) as img:
+                    width, height = img.size
+                    bytes_ = path.stat().st_size
+                    ext = path.suffix.lower()
+                    added_at = datetime.datetime.now().isoformat()
 
-        try:
-            with Image.open(path) as img:  # read image information
-                width, height = img.size
-                bytes_ = path.stat().st_size
-                ext = path.suffix.lower()
-                added_at = datetime.datetime.now().isoformat()
+                    connector.upsert_image(
+                        abs_path, width, height, ext, bytes_, added_at, conn=conn
+                    )
 
-                connector.upsert_image(  # using upsert_image from connector.py
-                    abs_path, width, height, ext, bytes_, added_at, db_path=db_path
-                )
+            except (
+                UnidentifiedImageError,
+                OSError,
+            ):  # If image cannot be identified or other OS error...
+                continue  # ...skip it.
 
-        except (
-            UnidentifiedImageError,
-            OSError,
-        ):  # If image cannot be identified or other OS error...
-            continue  # ...skip it.
-
-    total_ingested = connector.count(db_path=db_path)
-    print(f"Total images ingested: {total_ingested}")  # final count of ingested images after scan
+    print(
+        f"Total images ingested: {connector.count(db_path=db_path)}"
+    )  # final count of ingested images after scan
 
 
 def main():

--- a/tests/db/test_ingest_dryrun.py
+++ b/tests/db/test_ingest_dryrun.py
@@ -14,7 +14,9 @@ def test_ingest_dryrun(tmp_path):
     - A valid image file
     - An image file with the same path already in the DB
     """
-    samples_dir = Path(r"data\samples")  # directory with sample images
+    samples_dir = (
+        Path(__file__).resolve().parent.parent.parent / "data" / "samples"
+    )  # directory with sample images
     assert samples_dir.exists(), f"{samples_dir} does not exist."
 
     db_path = os.path.join(tmp_path, "test_samples.db")  # temporary DB

--- a/tests/db/test_ingest_dryrun.py
+++ b/tests/db/test_ingest_dryrun.py
@@ -8,29 +8,29 @@ from image_recommender.db import connector
 from image_recommender.ingest_metadata import scan_and_ingest_metadata
 
 
-def test_ingest_dryrun(tmp_path):
+def test_ingest_dryrun(tmp_path: Path) -> None:
     """
     Tests ingesting metadata from a directory containing:
     - A valid image file
     - An image file with the same path already in the DB
     """
-    samples_dir = (
+    samples_dir: Path = (
         Path(__file__).resolve().parent.parent.parent / "data" / "samples"
     )  # directory with sample images
     assert samples_dir.exists(), f"{samples_dir} does not exist."
 
-    db_path = os.path.join(tmp_path, "test_samples.db")  # temporary DB
-    test_dir = os.path.join(tmp_path, "copied_samples")
+    db_path: str = os.path.join(tmp_path, "test_samples.db")  # temporary DB
+    test_dir: str = os.path.join(tmp_path, "copied_samples")
     os.makedirs(test_dir, exist_ok=True)
 
-    connector.init_db(db_path=str(db_path))
+    connector.init_db(db_path=db_path)
 
     # ---------- COPY SAMPLE IMAGES ----------
 
-    copied_files = []
+    copied_files: list[str] = []
     for f in samples_dir.iterdir():
         if f.suffix.lower() in {".jpg", ".jpeg", ".png"}:  # pick valid image files
-            dst = os.path.join(test_dir, f.name)
+            dst: str = os.path.join(test_dir, f.name)
             shutil.copy(f, dst)  # use shutil to copy files
             copied_files.append(dst)
 
@@ -38,17 +38,17 @@ def test_ingest_dryrun(tmp_path):
 
     # ---------- CREATE INVALID IMAGE ----------
 
-    bad_file = os.path.join(test_dir, "invalid_image_file.png")
+    bad_file: str = os.path.join(test_dir, "invalid_image_file.png")
     with open(bad_file, "wb") as f:
         f.write(b"\x00\x00NOT_A_REAL_IMAGE")
 
     # ---------- INGEST CHECK ----------
 
-    scan_and_ingest_metadata(base_path=str(test_dir), db_path=str(db_path))  # ingestion on copy
+    scan_and_ingest_metadata(base_path=test_dir, db_path=db_path)  # ingestion on copy
 
     # ---------- VERIFY VALID FILES ----------
 
-    valid_files = []  # list of valid image files
+    valid_files: list[str] = []  # list of valid image files
     for f in copied_files:
         try:
             with Image.open(f):
@@ -56,7 +56,7 @@ def test_ingest_dryrun(tmp_path):
         except (UnidentifiedImageError, OSError):
             continue
 
-    assert connector.count(db_path=str(db_path)) == len(
+    assert connector.count(db_path=db_path) == len(
         valid_files
     )  # Are there as many images in the DB as valid files?
 
@@ -73,12 +73,12 @@ def test_ingest_dryrun(tmp_path):
 
     # ---------- IDMPOTENCE CHECK ----------
 
-    image_ids_before = {
+    image_ids_before: dict[str, int] = {
         f: connector.get_by_path(str(Path(f).resolve()), db_path=db_path)["image_id"]
         for f in valid_files
     }
 
-    scan_and_ingest_metadata(base_path=str(test_dir), db_path=str(db_path))
+    scan_and_ingest_metadata(base_path=test_dir, db_path=db_path)
 
     for f in valid_files:
         row = connector.get_by_path(str(Path(f).resolve()), db_path=db_path)
@@ -86,17 +86,17 @@ def test_ingest_dryrun(tmp_path):
             row["image_id"] == image_ids_before[f]
         )  # Are the IDs the same as before (idempotence)?
 
-    assert connector.count(db_path=str(db_path)) == len(
+    assert connector.count(db_path=db_path) == len(
         valid_files
     )  # Are there as many images in the DB as valid files?
 
     # ---------- ADD AN EXTRA BAD FILE ----------
 
-    extra_bad_file = os.path.join(test_dir, "corrupt_image.jpg")
+    extra_bad_file: str = os.path.join(test_dir, "corrupt_image.jpg")
     with open(extra_bad_file, "wb") as f:
         f.write(b"\x00\x00INVALID")
 
-    scan_and_ingest_metadata(base_path=str(test_dir), db_path=str(db_path))
+    scan_and_ingest_metadata(base_path=test_dir, db_path=db_path)
 
     assert (
         connector.get_by_path(str(Path(extra_bad_file).resolve()), db_path=db_path) is None

--- a/tests/db/test_ingest_dryrun.py
+++ b/tests/db/test_ingest_dryrun.py
@@ -1,0 +1,48 @@
+from image_recommender.db import connector
+from image_recommender.ingest_metadata import scan_and_ingest_metadata
+
+
+def test_ingest_dryrun(tmp_path):
+    """
+    Tests ingesting metadata from a directory containing:
+    - A valid image file
+    - An image file with the same path already in the DB
+    """
+    example_dir = tmp_path / "samples"
+    example_dir.mkdir()
+
+    img1 = example_dir / "img1.jpg"
+    img1.write_bytes(b"\xff\xd8\xff\xe0" + b"not really .jpeg")  # dummy JPEG content
+
+    db_path = tmp_path / "test.db"  # path to temporary DB
+
+    connector.init_db(db_path=str(db_path))  # initialize DB
+
+    connector.upsert_image(  # using upsert_image method from connector.py
+        path=str(img1.resolve()),
+        width=128,
+        height=256,
+        ext=".jpg",
+        bytes_=len(b"\xff\xd8\xff\xe0" + b"not really .jpeg"),
+        added_at="2020-01-01T00:00:00",
+        db_path=str(db_path),
+    )
+
+    bad_file = example_dir / "bad.png"  # invalid image file
+    bad_file.write_bytes(b"\x00\x00\x00INVALIDIMAGE")  # dummy invalid content
+
+    scan_and_ingest_metadata(
+        base_path=str(example_dir), db_path=str(db_path)  # what to scan  # where to store metadata
+    )
+
+    row = connector.get_by_path(str(img1.resolve()), db_path=str(db_path))
+
+    assert row is not None  # Is the row existing? It should be.
+    assert row["width"] == 128  # Was the width unchanged?
+
+    bad_row = connector.get_by_path(str(bad_file.resolve()), db_path=str(db_path))
+    assert bad_row is None  # Is the bad file ingested? It should not be.
+
+    assert (
+        connector.count(db_path=str(db_path)) == 1
+    )  # Is there only one row in DB? There should be.

--- a/tests/db/test_ingest_dryrun.py
+++ b/tests/db/test_ingest_dryrun.py
@@ -1,3 +1,9 @@
+import os
+import shutil
+from pathlib import Path
+
+from PIL import Image, UnidentifiedImageError
+
 from image_recommender.db import connector
 from image_recommender.ingest_metadata import scan_and_ingest_metadata
 
@@ -8,41 +14,79 @@ def test_ingest_dryrun(tmp_path):
     - A valid image file
     - An image file with the same path already in the DB
     """
-    example_dir = tmp_path / "samples"
-    example_dir.mkdir()
+    samples_dir = Path(r"data\samples")  # directory with sample images
+    assert samples_dir.exists(), f"{samples_dir} does not exist."
 
-    img1 = example_dir / "img1.jpg"
-    img1.write_bytes(b"\xff\xd8\xff\xe0" + b"not really .jpeg")  # dummy JPEG content
+    db_path = os.path.join(tmp_path, "test_samples.db")  # temporary DB
+    test_dir = os.path.join(tmp_path, "copied_samples")
+    os.makedirs(test_dir, exist_ok=True)
 
-    db_path = tmp_path / "test.db"  # path to temporary DB
+    connector.init_db(db_path=str(db_path))
 
-    connector.init_db(db_path=str(db_path))  # initialize DB
+    # ---------- COPY SAMPLE IMAGES ----------
 
-    connector.upsert_image(  # using upsert_image method from connector.py
-        path=str(img1.resolve()),
-        width=128,
-        height=256,
-        ext=".jpg",
-        bytes_=len(b"\xff\xd8\xff\xe0" + b"not really .jpeg"),
-        added_at="2020-01-01T00:00:00",
-        db_path=str(db_path),
-    )
+    copied_files = []
+    for f in samples_dir.iterdir():
+        if f.suffix.lower() in {".jpg", ".jpeg", ".png"}:  # pick valid image files
+            dst = os.path.join(test_dir, f.name)
+            shutil.copy(f, dst)  # use shutil to copy files
+            copied_files.append(dst)
 
-    bad_file = example_dir / "bad.png"  # invalid image file
-    bad_file.write_bytes(b"\x00\x00\x00INVALIDIMAGE")  # dummy invalid content
+    assert len(copied_files) > 0, "There must be at least one sample image"
 
-    scan_and_ingest_metadata(
-        base_path=str(example_dir), db_path=str(db_path)  # what to scan  # where to store metadata
-    )
+    # ---------- CREATE INVALID IMAGE ----------
 
-    row = connector.get_by_path(str(img1.resolve()), db_path=str(db_path))
+    bad_file = os.path.join(test_dir, "invalid_image_file.png")
+    with open(bad_file, "wb") as f:
+        f.write(b"\x00\x00NOT_A_REAL_IMAGE")
 
-    assert row is not None  # Is the row existing? It should be.
-    assert row["width"] == 128  # Was the width unchanged?
+    # ---------- INGEST CHECK ----------
 
-    bad_row = connector.get_by_path(str(bad_file.resolve()), db_path=str(db_path))
-    assert bad_row is None  # Is the bad file ingested? It should not be.
+    scan_and_ingest_metadata(base_path=str(test_dir), db_path=str(db_path))  # ingestion on copy
+
+    # ---------- VERIFY VALID FILES ----------
+
+    valid_files = []  # list of valid image files
+    for f in copied_files:
+        try:
+            with Image.open(f):
+                valid_files.append(f)
+        except (UnidentifiedImageError, OSError):
+            continue
+
+    assert connector.count(db_path=str(db_path)) == len(
+        valid_files
+    )  # Are there as many images in the DB as valid files?
+
+    for f in valid_files:
+        row = connector.get_by_path(str(Path(f).resolve()), db_path=db_path)
+        assert row is not None
+        assert Path(row["path"]).is_absolute()
+        assert row["ext"] == os.path.splitext(f)[1].lower()  # Are the extensions the same?
+
+    # ---------- IDMPOTENCE CHECK ----------
+
+    image_ids_before = {
+        f: connector.get_by_path(str(Path(f).resolve()), db_path=db_path)["image_id"]
+        for f in valid_files
+    }
+
+    scan_and_ingest_metadata(base_path=str(test_dir), db_path=str(db_path))
+
+    for f in valid_files:
+        row = connector.get_by_path(str(Path(f).resolve()), db_path=db_path)
+        assert (
+            row["image_id"] == image_ids_before[f]
+        )  # Are the IDs the same as before (idempotence)?
+
+    # ---------- ADD AN EXTRA BAD FILE ----------
+
+    extra_bad_file = os.path.join(test_dir, "corrupt_image.jpg")
+    with open(extra_bad_file, "wb") as f:
+        f.write(b"\x00\x00INVALID")
+
+    scan_and_ingest_metadata(base_path=str(test_dir), db_path=str(db_path))
 
     assert (
-        connector.count(db_path=str(db_path)) == 1
-    )  # Is there only one row in DB? There should be.
+        connector.get_by_path(str(Path(extra_bad_file).resolve()), db_path=db_path) is None
+    )  # Is the bad file ignored?

--- a/tests/db/test_ingest_dryrun.py
+++ b/tests/db/test_ingest_dryrun.py
@@ -61,10 +61,15 @@ def test_ingest_dryrun(tmp_path):
     )  # Are there as many images in the DB as valid files?
 
     for f in valid_files:
-        row = connector.get_by_path(str(Path(f).resolve()), db_path=db_path)
-        assert row is not None
-        assert Path(row["path"]).is_absolute()
-        assert row["ext"] == os.path.splitext(f)[1].lower()  # Are the extensions the same?
+        with Image.open(f) as img:
+            row = connector.get_by_path(str(Path(f).resolve()), db_path=db_path)
+            assert row is not None  # Does the image exist in the DB?
+            assert Path(row["path"]).is_absolute()  # Is the path absolute?
+            assert row["ext"] == os.path.splitext(f)[1].lower()  # Are the extensions the same?
+            assert row["width"] == img.width, f"Width mismatch for {f}"  # Are the widths the same?
+            assert (
+                row["height"] == img.height
+            ), f"Height mismatch for {f}"  # Are the heights the same?
 
     # ---------- IDMPOTENCE CHECK ----------
 
@@ -80,6 +85,10 @@ def test_ingest_dryrun(tmp_path):
         assert (
             row["image_id"] == image_ids_before[f]
         )  # Are the IDs the same as before (idempotence)?
+
+    assert connector.count(db_path=str(db_path)) == len(
+        valid_files
+    )  # Are there as many images in the DB as valid files?
 
     # ---------- ADD AN EXTRA BAD FILE ----------
 


### PR DESCRIPTION
## Linked Issue
<!-- REQUIRED: link the primary issue (e.g. "Closes #123") -->
Closes #16

## Summary (Delta vs Issue)
- Recognized extensions are implicitly defined by what PIL can open.
- Logging and CSV export are out of scope, as agreed in prior discussions.

## Scope
<!-- Short bullets of what this PR actually changes/adds. No future work. -->
- Metadata ingestion (scan_and_ingest_metadata) --> read files, extract metadata, upsert

## How Tested / Evidence
<!-- What proves it works? Paste commands & outcomes; attach logs/screens if useful. -->
-  Tested with tests/db/test_ingest_dryrun.py
<pre> pytest -q tests/db/test_ingest_dryrun.py --> Result: 1 passed in 0.44 s </pre>

## Risk & Rollback (optional)
<!-- Any side effects? How to revert safely if needed. -->

## Notes for Reviewers (optional)
<!-- Call out tricky parts, follow-up PRs, or decisions deviating from the issue. -->

## Checklist
- [x] Labels set (area, block, priority)
- [x]  CI passes (lint-format, tests, cli-smoke)
- [x] Tests updated/added (only for what this PR changes)