### PR TITLE
Feature/issue 13/core image loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,18 +5,21 @@ on:
   push:                  # and on pushes to main
     branches: [main]
 
+# call reusable workflow for tasks
 jobs:
   # lint & format via pre commit action (ruff + black hooks from repo config)
   lint-format:
-    uses: l1l1th11/image-recommender/.github/workflows/python-job.yml@main
-    with: { task: lint-format }
+    uses: ./.github/workflows/python-job.yml
+    with: 
+      task: lint-format
 
   # unit tests (pytest)
   tests:
-    uses: l1l1th11/image-recommender/.github/workflows/python-job.yml@main
-    with: { task: tests }
+    uses: ./.github/workflows/python-job.yml
+    with: 
+      task: tests
 
-  # tiny cli smoke (import & basic command)
   cli-smoke:
-    uses: l1l1th11/image-recommender/.github/workflows/python-job.yml@main
-    with: { task: cli-smoke }
+    uses: ./.github/workflows/python-job.yml
+    with: 
+      task: cli-smoke

--- a/.github/workflows/python-job.yml
+++ b/.github/workflows/python-job.yml
@@ -23,7 +23,7 @@ jobs:
       - name: check out repo
         uses: actions/checkout@v4
 
-      - name: set up Python
+      - name: set up python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python }}  # lets caller override if needed
@@ -43,13 +43,14 @@ jobs:
       - name: run pytest
         if: ${{ inputs.task == 'tests' }}
         run: |
-          pip install pytest
+          # install package, runtime deps and test deps from pyproject
+          pip install -e '.[test]'
           pytest -q
 
       - name: cli smoke
         if: ${{ inputs.task == 'cli-smoke' }}
         run: |
-          # show cli help (validates argparse wiring)
+          # show cli help (validate argparse wiring)
           python -m image_recommender.cli --help
           # list max one sample (empty dir won't error)
           python -m image_recommender.cli list-samples --limit 1

--- a/environment.yml
+++ b/environment.yml
@@ -3,4 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - python=3.12
+  - numpy
+  - pillow
   - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,13 @@ build-backend = "setuptools.build_meta"
 # package metadata
 name = "image-recommender"
 version = "0.0.1"
+requires-python = ">=3.12"
+# runtime deps
+dependencies = ["numpy", "pillow"]
+
+[project.optional-dependencies]
+# test deps
+test = ["pytest"]
 
 [tool.setuptools]
 # map root of packages to src/

--- a/src/image_recommender/io/img_loader.py
+++ b/src/image_recommender/io/img_loader.py
@@ -28,28 +28,28 @@ def load_rgb(path: str | Path) -> np.ndarray:
             img_array = np.asarray(img)  # decoding/materialize may raise OSError
 
     except FileNotFoundError as e:
-        msg = f"{__name__} | {path} | file not found"
+        msg = f"{path} | file not found"
         log.error(msg)
         raise ImageLoadError(msg) from e
 
     except UnidentifiedImageError as e:
-        msg = f"{__name__} | {path} | unidentified/unsupported image"
+        msg = f"{path} | unidentified/unsupported image"
         log.error(msg)
         raise ImageLoadError(msg) from e
 
     except OSError as e:
-        msg = f"{__name__} | {path} | corrupt or unreadable image"
+        msg = f"{path} | corrupt or unreadable image"
         log.error(msg)
         raise ImageLoadError(msg) from e
 
     except Exception as e:
-        msg = f"{__name__} | {path} | unexpected error: {e.__class__.__name__}"
+        msg = f"{path} | unexpected error: {e.__class__.__name__}"
         log.error(msg)
         raise ImageLoadError(msg) from e
 
     # validate final shape
     if img_array.ndim != 3 or img_array.shape[2] != 3:
-        msg = f"{__name__} | {path} | invalid shape {tuple(img_array.shape)} (expected [H,W,3])"
+        msg = f"{path} | invalid shape {tuple(img_array.shape)} (expected [H,W,3])"
         log.error(msg)
         raise ImageLoadError(msg)
 

--- a/src/image_recommender/io/img_loader.py
+++ b/src/image_recommender/io/img_loader.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+import numpy as np
+from PIL import Image, UnidentifiedImageError
+
+from image_recommender.util.errors import ImageLoadError
+from image_recommender.util.logs import get_logger
+
+# module level logger
+log = get_logger(__name__)  # pass modules name
+
+
+def load_rgb(path: str | Path) -> np.ndarray:
+    """
+    Loads an image from a given path using PIL (lazy)
+    """
+    # convert to path object
+    path = Path(path)
+
+    try:
+        # open with context manager
+        with Image.open(path) as img:  # may raise FileNotFoundError, UnidentifiedImageError
+
+            # convert to RGB
+            img = img.convert("RGB")  # decoding may raise OSError (corrupt/truncated)
+
+            # convert to array (shape: H, W, 3)
+            img_array = np.asarray(img)  # decoding/materialize may raise OSError
+
+    except FileNotFoundError as e:
+        msg = f"{__name__} | {path} | file not found"
+        log.error(msg)
+        raise ImageLoadError(msg) from e
+
+    except UnidentifiedImageError as e:
+        msg = f"{__name__} | {path} | unidentified/unsupported image"
+        log.error(msg)
+        raise ImageLoadError(msg) from e
+
+    except OSError as e:
+        msg = f"{__name__} | {path} | corrupt or unreadable image"
+        log.error(msg)
+        raise ImageLoadError(msg) from e
+
+    except Exception as e:
+        msg = f"{__name__} | {path} | unexpected error: {e.__class__.__name__}"
+        log.error(msg)
+        raise ImageLoadError(msg) from e
+
+    # validate final shape
+    if img_array.ndim != 3 or img_array.shape[2] != 3:
+        msg = f"{__name__} | {path} | invalid shape {tuple(img_array.shape)} (expected [H,W,3])"
+        log.error(msg)
+        raise ImageLoadError(msg)
+
+    return img_array

--- a/src/image_recommender/util/errors.py
+++ b/src/image_recommender/util/errors.py
@@ -1,0 +1,8 @@
+# util/errors.py
+"""Custom exception types used across the project"""
+
+
+class ImageLoadError(Exception):
+    """Project-wide exception for image loading failures"""
+
+    pass

--- a/tests/io/test_img_loader.py
+++ b/tests/io/test_img_loader.py
@@ -1,0 +1,60 @@
+import logging
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+import image_recommender.io.img_loader as mod
+from image_recommender.util.errors import ImageLoadError
+
+
+@pytest.fixture
+# create temporary directory
+def samples_dir(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+def test_happy_path(samples_dir):
+    # create path
+    happy_path = samples_dir / "rgb.jpeg"
+    # create image
+    happy_img = Image.new(mode="RGB", size=(10, 15), color=(10, 20, 30))  # size: width, height
+    # save image to path
+    happy_img.save(happy_path, format="JPEG")
+    # load image
+    happy_array = mod.load_rgb(happy_path)
+    # should return rgb array of type uint8
+    assert happy_array.shape == (15, 10, 3)  # shape: height, width, channels
+    assert happy_array.dtype == np.uint8
+
+
+def test_gray_to_rgb(samples_dir):
+    gray_path = samples_dir / "gray.png"
+    gray_img = Image.new(mode="L", size=(20, 10), color=42)  # grayscale
+    gray_img.save(gray_path, format="PNG")
+    rgb_array = mod.load_rgb(gray_path)
+    # should now be rgb array of type uint8
+    assert rgb_array.shape == (10, 20, 3)
+    assert rgb_array.dtype == np.uint8
+
+
+def test_non_img(samples_dir, caplog):
+    caplog.set_level(logging.ERROR)
+    non_img_path = samples_dir / "non_img.txt"
+    non_img_path.write_text("test")
+    # raise custom error (wraps PIL errors)
+    with pytest.raises(ImageLoadError):
+        mod.load_rgb(non_img_path)
+    # retrieve logs
+    records = [r for r in caplog.records if r.levelname == "ERROR"]
+    # only one log captured
+    assert len(records) == 1
+    # module included
+    rec = records[0]
+    assert str(mod.__name__) == rec.name
+    # path included
+    msg = rec.getMessage()  # retrieve log
+    assert str(non_img_path) in msg
+    # reason included
+    assert "unidentified/unsupported image" in msg


### PR DESCRIPTION
## Linked Issue
<!-- REQUIRED: link the primary issue (e.g. "Closes #123") -->
Closes #13 

## Summary (Delta vs Issue)
<!-- What changed compared to the issue plan? If exactly as planned, say "Matches issue." -->
The ERROR message is "path | reason" while the module comes from the logger name via formatter (%(name)s), avoiding duplication (single log line preserved).

## Scope
<!-- Short bullets of what this PR actually changes/adds. No future work. -->
- io/img_loader.py:
> load_rgb(path: Path | str) -> np.ndarray[H,W,3] using PIL -> .convert("RGB") → np.asarray guarantees RGB, dtype=uint8, shape [H,W,3]
> on failure: logs exactly one ERROR with "<path> | <reason>" (module via logger name) and raises util.errors.ImageLoadError with exception chaining
> maps common errors: FileNotFound/UnidentifiedImage/OSError/generic

- tests/io/test_img_loader.py:
> JPG happy path -> shape/dtype.
> grayscale PNG -> RGB (3 channels)
> non-image .txt -> ImageLoadError, exactly one ERROR record

- environment.yml:
> added pillow and numpy

## How Tested / Evidence
<!-- What proves it works? Paste commands & outcomes; attach logs/screens if useful. -->
-  pytest -q -> all tests pass
- Example log: ERROR | image_recommender.io.img_loader | C:\path\to\file.txt | unidentified/unsupported image

## Risk & Rollback (optional)
<!-- Any side effects? How to revert safely if needed. -->

## Notes for Reviewers (optional)
<!-- Call out tricky parts, follow-up PRs, or decisions deviating from the issue. -->
Nice-to-haves (extra formats, timing DEBUG) intentionally deferred.

## Checklist
- [x] Labels set (area, block, priority)
- [x] CI passes (lint-format, tests, cli-smoke)
- [x] Tests updated/added (only for what this PR changes)
- [ ] Docs/README updated if needed
