### PR TITLE
Feature/issue 32/embedding extractor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ name = "image-recommender"
 version = "0.0.1"
 requires-python = ">=3.12"
 # runtime deps
-dependencies = ["numpy", "pillow", "tqdm", "opencv-python"]
+dependencies = ["numpy", "pillow", "tqdm", "opencv-python", "torch", "torchvision"]
 
 [project.optional-dependencies]
 # test deps

--- a/src/image_recommender/features/embedding.py
+++ b/src/image_recommender/features/embedding.py
@@ -1,0 +1,82 @@
+import numpy as np
+import torch
+import torchvision.models as models
+from PIL import Image
+from torchvision import transforms
+
+_preprocess = transforms.Compose(
+    [
+        transforms.ToTensor(),
+        transforms.Normalize(
+            mean=[0.485, 0.456, 0.406],  # these are standard ImageNet means and stds
+            std=[0.229, 0.224, 0.225],
+        ),
+    ]
+)
+
+_model_cache = {}  # cache models to avoid reloading
+_embedding_dims = {}
+
+
+def _load_model(model_name: str, pretrained: bool = True, device: str = "cpu") -> torch.nn.Module:
+    """
+    Loads a ResNet model.
+    Caches models for deterministic output.
+    """
+    key = (model_name, pretrained, device)  # key for caching
+    if key in _model_cache:
+        return _model_cache[key]  # avoid reloading of cached models
+
+    model_choices = {
+        "resnet18": models.resnet18,  # default
+        "resnet34": models.resnet34,
+        "resnet50": models.resnet50,
+        "resnet101": models.resnet101,
+        "resnet152": models.resnet152,
+    }
+
+    model_cls = model_choices.get(model_name)  # model class --> instantiate model
+    if model_cls is None:
+        raise ValueError(f"Unsupported model_name: {model_name}")
+
+    model = model_cls(pretrained=pretrained)  # either pretrained or random init
+    model = torch.nn.Sequential(*list(model.children())[:-1])  # all layers without fully-connected
+    model.eval()  # inference
+    model.to(device)  # either cpu or gpu (cuda)
+
+    with torch.no_grad():
+        dummy = torch.zeros(1, 3, 224, 224, device=device)  # dummy input for dimension inference
+        out = model(dummy)  # inference (forward pass)
+        _embedding_dims[model_name] = int(out.numel())  # dimension of output embedding
+
+    _model_cache[key] = model
+    return model
+
+
+def get_embedding_dim(model_name: str = "resnet18") -> int:  # set resnet18 as default
+    if model_name not in _embedding_dims:  # If not cached...
+        _load_model(model_name, pretrained=False)  # ... load model to get dimension
+    return _embedding_dims[model_name]
+
+
+def extract_embedding(  # main function to extract embedding from RGB image
+    img_rgb: np.ndarray,
+    *,
+    model_name: str = "resnet18",
+    pretrained: bool = True,
+    device: str = "cpu",
+) -> np.ndarray:
+
+    if img_rgb.ndim != 3 or img_rgb.shape[2] != 3:  # image must be RGB (3 channels)
+        raise ValueError("Input must be RGB image with shape (H, W, 3)")
+
+    img = Image.fromarray(img_rgb)  # NumPy --> PIL Image
+    x = _preprocess(img).unsqueeze(0).to(device)  # preprocess and add batch dimension
+
+    model = _load_model(model_name, pretrained=pretrained, device=device)  # get model
+    with torch.no_grad():  # If inference is without gradient computation...
+        y = model(x)  # ... return embedding in shape of (1, D, 1, 1)
+
+    return (
+        y.squeeze().cpu().numpy().astype(np.float32)
+    )  # remove batch dimension and convert to NumPy array

--- a/src/image_recommender/features/embedding.py
+++ b/src/image_recommender/features/embedding.py
@@ -18,11 +18,20 @@ _model_cache = {}  # cache models to avoid reloading
 _embedding_dims = {}
 
 
-def _load_model(model_name: str, pretrained: bool = True, device: str = "cpu") -> torch.nn.Module:
+def _get_default_device() -> str:
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def _load_model(
+    model_name: str, pretrained: bool = True, device: str | None = None
+) -> torch.nn.Module:
     """
     Loads a ResNet model.
     Caches models for deterministic output.
     """
+    if device is None:
+        device = _get_default_device()
+
     key = (model_name, pretrained, device)  # key for caching
     if key in _model_cache:
         return _model_cache[key]  # avoid reloading of cached models
@@ -64,8 +73,11 @@ def extract_embedding(  # main function to extract embedding from RGB image
     *,
     model_name: str = "resnet18",
     pretrained: bool = True,
-    device: str = "cpu",
+    device: str | None = None,
 ) -> np.ndarray:
+
+    if device is None:
+        device = _get_default_device()
 
     if img_rgb.ndim != 3 or img_rgb.shape[2] != 3:  # image must be RGB (3 channels)
         raise ValueError("Input must be RGB image with shape (H, W, 3)")
@@ -80,3 +92,37 @@ def extract_embedding(  # main function to extract embedding from RGB image
     return (
         y.squeeze().cpu().numpy().astype(np.float32)
     )  # remove batch dimension and convert to NumPy array
+
+
+def extract_embeddings_batch(
+    imgs_rgb: list[np.ndarray],  # list of images
+    *,  # folliwing parameters are keyword-only
+    model_name: str = "resnet18",
+    pretrained: bool = True,
+    device: str | None = None,
+    batch_size: int = 8,
+) -> np.ndarray:
+    """
+    Extracts embeddings for multiple RGB images in batches.
+    """
+    if device is None:
+        device = _get_default_device()
+
+    if not imgs_rgb:  # If there are no images...
+        return np.empty(
+            (0, get_embedding_dim(model_name)), dtype=np.float32
+        )  # ... return an empty array
+
+    model = _load_model(model_name, pretrained=pretrained, device=device)
+    embeddings = []
+
+    for i in range(0, len(imgs_rgb), batch_size):  # iterate over imgaes in batches
+        batch_imgs = imgs_rgb[i : i + batch_size]
+        tensors = [_preprocess(Image.fromarray(img)).unsqueeze(0) for img in batch_imgs]
+        x = torch.cat(tensors, dim=0).to(device)
+        with torch.no_grad():
+            y = model(x)
+        batch_emb = y.view(len(batch_imgs), -1).cpu().numpy()  # flatten and convert to NumPy
+        embeddings.append(batch_emb)
+
+    return np.vstack(embeddings).astype(np.float32)  # stack all batches into a single array

--- a/src/image_recommender/features/embedding.py
+++ b/src/image_recommender/features/embedding.py
@@ -13,6 +13,8 @@ from torchvision.models import (
 
 _preprocess = transforms.Compose(
     [
+        transforms.Resize(256),
+        transforms.CenterCrop(224),
         transforms.ToTensor(),
         transforms.Normalize(
             mean=[0.485, 0.456, 0.406],  # these are standard ImageNet means and stds
@@ -26,7 +28,7 @@ _embedding_dims = {}
 
 
 def _get_default_device() -> str:
-    return "cpu"  # <-- if necessary, modify to use GPU with "cuda"
+    return "cpu"
 
 
 _weights = {
@@ -38,19 +40,23 @@ _weights = {
 }
 
 
-def _load_model(
-    model_name: str, pretrained: bool = True, device: str | None = None
-) -> torch.nn.Module:
+def _load_model(model_name: str, pretrained: bool = True, device: str = "cpu") -> torch.nn.Module:
     """
     Loads a ResNet model.
     Caches models for deterministic output.
     """
-    if device is None:
-        device = _get_default_device()
+    if pretrained and model_name not in _weights:
+        raise ValueError(
+            f"pretrained=True, but model_name='{model_name}' has no ResNet weights. "
+            f"Valid options: {list(_weights.keys())}"
+        )
 
     key = (model_name, pretrained, device)  # key for caching
     if key in _model_cache:
         return _model_cache[key]  # avoid reloading of cached models
+
+    if model_name not in models.__dict__:
+        raise ValueError(f"Unsupported model_name: {model_name}")
 
     model_cls = models.__dict__[model_name]
 
@@ -86,7 +92,7 @@ def extract_embedding(  # main function to extract embedding from RGB image
     *,
     model_name: str = "resnet18",
     pretrained: bool = True,
-    device: str | None = None,
+    device: str = "cpu",
 ) -> np.ndarray:
     """
     Extracts an embedding from a single RGB image.
@@ -96,10 +102,6 @@ def extract_embedding(  # main function to extract embedding from RGB image
         - pretrained: Whether to use pretrained weights.
         - device: Device to run inference on.
     """
-
-    if device is None:
-        device = _get_default_device()
-
     if img_rgb.ndim != 3 or img_rgb.shape[2] != 3:  # image must be RGB (3 channels)
         raise ValueError("Input must be RGB image with shape (H, W, 3)")
 
@@ -118,7 +120,7 @@ def extract_embeddings_batch(
     *,  # folliwing parameters are keyword-only
     model_name: str = "resnet18",
     pretrained: bool = True,
-    device: str | None = None,
+    device: str = "cpu",
     batch_size: int = 8,
 ) -> np.ndarray:
     """
@@ -130,9 +132,6 @@ def extract_embeddings_batch(
         - device: Device to run inference on.
         - batch_size: Number of images to process in each batch.
     """
-    if device is None:
-        device = _get_default_device()
-
     if not imgs_rgb:  # If there are no images...
         return np.empty(
             (0, get_embedding_dim(model_name)), dtype=np.float32

--- a/src/image_recommender/features/embedding.py
+++ b/src/image_recommender/features/embedding.py
@@ -3,6 +3,13 @@ import torch
 import torchvision.models as models
 from PIL import Image
 from torchvision import transforms
+from torchvision.models import (
+    ResNet18_Weights,
+    ResNet34_Weights,
+    ResNet50_Weights,
+    ResNet101_Weights,
+    ResNet152_Weights,
+)
 
 _preprocess = transforms.Compose(
     [
@@ -19,7 +26,16 @@ _embedding_dims = {}
 
 
 def _get_default_device() -> str:
-    return "cuda" if torch.cuda.is_available() else "cpu"
+    return "cpu"  # <-- if necessary, modify to use GPU with "cuda"
+
+
+_weights = {
+    "resnet18": ResNet18_Weights.DEFAULT,
+    "resnet34": ResNet34_Weights.DEFAULT,
+    "resnet50": ResNet50_Weights.DEFAULT,
+    "resnet101": ResNet101_Weights.DEFAULT,
+    "resnet152": ResNet152_Weights.DEFAULT,
+}
 
 
 def _load_model(
@@ -36,19 +52,16 @@ def _load_model(
     if key in _model_cache:
         return _model_cache[key]  # avoid reloading of cached models
 
-    model_choices = {
-        "resnet18": models.resnet18,  # default
-        "resnet34": models.resnet34,
-        "resnet50": models.resnet50,
-        "resnet101": models.resnet101,
-        "resnet152": models.resnet152,
-    }
+    model_cls = models.__dict__[model_name]
 
-    model_cls = model_choices.get(model_name)  # model class --> instantiate model
     if model_cls is None:
         raise ValueError(f"Unsupported model_name: {model_name}")
 
-    model = model_cls(pretrained=pretrained)  # either pretrained or random init
+    if pretrained:
+        model = model_cls(weights=_weights[model_name])
+    else:
+        model = model_cls(weights=None)
+
     model = torch.nn.Sequential(*list(model.children())[:-1])  # all layers without fully-connected
     model.eval()  # inference
     model.to(device)  # either cpu or gpu (cuda)
@@ -75,6 +88,14 @@ def extract_embedding(  # main function to extract embedding from RGB image
     pretrained: bool = True,
     device: str | None = None,
 ) -> np.ndarray:
+    """
+    Extracts an embedding from a single RGB image.
+    Args:
+        - img_rgb: Input image as a NumPy array of shape (H, W, 3), expects uint8 RGB.
+        - model_name: Name of the ResNet model to use.
+        - pretrained: Whether to use pretrained weights.
+        - device: Device to run inference on.
+    """
 
     if device is None:
         device = _get_default_device()
@@ -87,11 +108,9 @@ def extract_embedding(  # main function to extract embedding from RGB image
 
     model = _load_model(model_name, pretrained=pretrained, device=device)  # get model
     with torch.no_grad():  # If inference is without gradient computation...
-        y = model(x)  # ... return embedding in shape of (1, D, 1, 1)
-
-    return (
-        y.squeeze().cpu().numpy().astype(np.float32)
-    )  # remove batch dimension and convert to NumPy array
+        y = model(x)
+        emb = y.view(-1).cpu().numpy().astype(np.float32)
+        return emb
 
 
 def extract_embeddings_batch(
@@ -104,6 +123,12 @@ def extract_embeddings_batch(
 ) -> np.ndarray:
     """
     Extracts embeddings for multiple RGB images in batches.
+    Args:
+        - imgs_rgb: List of RGB images as NumPy arrays of shape (H, W, 3), expects uint8 RGB.
+        - model_name: Name of the ResNet model to use.
+        - pretrained: Whether to use pretrained weights.
+        - device: Device to run inference on.
+        - batch_size: Number of images to process in each batch.
     """
     if device is None:
         device = _get_default_device()

--- a/tests/features/test_embedding.py
+++ b/tests/features/test_embedding.py
@@ -3,7 +3,11 @@ import os
 import numpy as np
 import pytest
 
-from image_recommender.features.embedding import extract_embedding, get_embedding_dim
+from image_recommender.features.embedding import (
+    extract_embedding,
+    extract_embeddings_batch,
+    get_embedding_dim,
+)
 
 
 def _dummy_img(seed: int = 0) -> np.ndarray:
@@ -27,3 +31,29 @@ def test_local_smoke_pretrained_true():
     emb = extract_embedding(img, pretrained=True)
     assert emb.shape[0] == get_embedding_dim("resnet18")
     assert emb.dtype == np.float32
+
+
+def test_batch_embedding_shape_and_consistency():
+    imgs = [_dummy_img(1), _dummy_img(2), _dummy_img(3)]
+    singles = [extract_embedding(img, pretrained=False) for img in imgs]
+    batch = extract_embeddings_batch(imgs, pretrained=False, batch_size=2)
+    assert batch.shape == (3, singles[0].shape[0])  # Has the embedding correct shape?
+    for i in range(3):
+        np.testing.assert_allclose(
+            batch[i], singles[i], rtol=1e-5, atol=1e-6
+        )  # Are embeddings within tolerance?
+
+
+def test_determinism_pretrained_false():
+    img = _dummy_img(42)
+    emb1 = extract_embedding(img, pretrained=False)
+    emb2 = extract_embedding(img, pretrained=False)
+    np.testing.assert_array_equal(emb1, emb2)  # Are embeddings (for same seed) exactly equal?
+
+
+def test_embedding_changes_with_input():
+    img1 = np.zeros((224, 224, 3), dtype=np.uint8)
+    img2 = np.ones((224, 224, 3), dtype=np.uint8) * 255
+    emb1 = extract_embedding(img1, pretrained=False)
+    emb2 = extract_embedding(img2, pretrained=False)
+    assert not np.allclose(emb1, emb2)  # Are embeddings different for distinct inputs?

--- a/tests/features/test_embedding.py
+++ b/tests/features/test_embedding.py
@@ -1,0 +1,29 @@
+import os
+
+import numpy as np
+import pytest
+
+from image_recommender.features.embedding import extract_embedding, get_embedding_dim
+
+
+def _dummy_img(seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return rng.integers(0, 256, size=(224, 224, 3), dtype=np.uint8)
+
+
+def test_single_embedding_shape_and_dtype():
+    img = _dummy_img()
+    emb = extract_embedding(img, pretrained=False)
+    assert emb.ndim == 1  # Is the embedding one-dimensional?
+    assert emb.dtype == np.float32  # Is the embedding of type float32?
+    assert emb.shape[0] == get_embedding_dim(
+        "resnet18"
+    )  # Does the embedding have the correct dimension?
+
+
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="Skip heavy pretrained test in CI")
+def test_local_smoke_pretrained_true():
+    img = _dummy_img()
+    emb = extract_embedding(img, pretrained=True)
+    assert emb.shape[0] == get_embedding_dim("resnet18")
+    assert emb.dtype == np.float32


### PR DESCRIPTION
## Linked Issue
<!-- REQUIRED: link the primary issue (e.g. "Closes #123") -->
Closes #32

## Summary (Delta vs Issue)
<!-- What changed compared to the issue plan? If exactly as planned, say "Matches issue." -->
Implemented embedding extractor using torchvision ResNet instead of timm.

## Scope
<!-- Short bullets of what this PR actually changes/adds. No future work. -->
- extract_embedding function for single RGB images
- extract_embeddings_batch function for multiple RGB images in batches
- get_embedding_dim helper to return embedding dimensionality
- torchvision ResNet models (resnet18, 34, 50, 101, 152) for feature extraction

## How Tested / Evidence
<!-- What proves it works? Paste commands & outcomes; attach logs/screens if useful. -->
-  Tested with tests/features/test_embedding.py
<pre>  pytest -q tests/features/test_embedding.py --> Result: 5 passed, 4 warnings in 4.74 s </pre>

## Risk & Rollback (optional)
<!-- Any side effects? How to revert safely if needed. -->

## Notes for Reviewers (optional)
<!-- Call out tricky parts, follow-up PRs, or decisions deviating from the issue. -->

## Checklist
- [x] Labels set (area, block, priority)
- [x] CI passes (lint-format, tests, cli-smoke)
- [x] Tests updated/added (only for what this PR changes)