### PR TITLE
Feature/issue 36/image iterator

### DIFF
--- a/data/samples/cat.jpg
+++ b/data/samples/cat.jpg
@@ -1,1 +1,0 @@
-placeholder

--- a/data/samples/dog.png
+++ b/data/samples/dog.png
@@ -1,1 +1,0 @@
-placeholder

--- a/src/image_recommender/constants.py
+++ b/src/image_recommender/constants.py
@@ -2,5 +2,7 @@ from pathlib import Path
 
 SAMPLES_DIR = Path("data/samples")
 
+PILOT_IDS_CSV = Path("data/pilot/pilot_1k_ids.csv")
+
 # normalized image extensions (lowercase, no dot)
 IMAGE_EXTS: set[str] = {"jpg", "jpeg", "png", "gif", "svg", "webp", "tif", "tiff"}

--- a/src/image_recommender/db/connector.py
+++ b/src/image_recommender/db/connector.py
@@ -91,11 +91,51 @@ def get_by_path(path: str, db_path: str | None = None) -> sqlite3.Row | None:
 
 
 def get_path_by_id(image_id: int, db_path: str | None = None) -> str | None:
-    """Retrieves only the file path for a given image_id."""
+    """
+    Retrieves only the file path for a given image_id.
+    """
     with get_conn(db_path=db_path) as conn:
         cur = conn.execute("SELECT path FROM images WHERE image_id = ?", (image_id,))
         row = cur.fetchone()
         return row["path"] if row else None
+
+
+def iter_id_paths(
+    start: int = 0, stop: int | None = None, db_path: str | None = None
+) -> Iterator[tuple[int, str]]:
+    """
+    Yields tuples of image_id and path.
+    Ordered by image_id.
+    0 based index slicing, start inclusive, stop exclusive.
+    Iterates from start to end if stop is None.
+    """
+    # validate slice bounds
+    if start < 0:
+        raise ValueError("start can not be negative")
+    if (stop is not None) and (stop < start):
+        raise ValueError("stop can not be smaller than start")
+
+    offset = start
+
+    with get_conn(db_path=db_path) as conn:
+        # bounded slice
+        if stop is not None:
+            limit = stop - start
+            cur = conn.execute(
+                "SELECT image_id, path FROM images ORDER BY image_id LIMIT ? OFFSET ?",
+                (limit, offset),
+            )
+        # offset to end
+        elif (stop is None) and (start > 0):
+            cur = conn.execute(
+                "SELECT image_id, path FROM images ORDER BY image_id LIMIT -1 OFFSET ?", (offset,)
+            )  # sqlite requires LIMIT with OFFSET, LIMIT -1 = no limit
+        # full table
+        else:
+            cur = conn.execute("SELECT image_id, path FROM images ORDER BY image_id")
+
+        for row in cur:
+            yield (row["image_id"], row["path"])
 
 
 # ---------- DELETE ----------

--- a/src/image_recommender/io/img_iterator.py
+++ b/src/image_recommender/io/img_iterator.py
@@ -1,8 +1,10 @@
 from collections.abc import Iterator
+from pathlib import Path
 
 import numpy as np
 
-from image_recommender.db.connector import iter_id_paths
+from image_recommender.constants import PILOT_IDS_CSV
+from image_recommender.db.connector import get_path_by_id, iter_id_paths
 from image_recommender.io.img_loader import load_rgb
 from image_recommender.util.errors import ImageLoadError
 from image_recommender.util.logs import get_logger
@@ -11,7 +13,9 @@ from image_recommender.util.logs import get_logger
 log = get_logger(__name__)  # pass modules name
 
 
-# for full runs
+# ---------------------------- DB Run ---------------------------------
+
+
 def iter_id_images_from_db(
     start: int = 0,
     stop: int | None = None,
@@ -52,3 +56,106 @@ def iter_id_images_from_db(
                 raise ImageLoadError(msg) from e
 
         yield image_id, img_array
+
+
+# ---------------------------- Pilot Run ---------------------------------
+
+
+def iter_ids_pilot(
+    start: int = 0, stop: int | None = None, pilot_path: str | Path = PILOT_IDS_CSV
+) -> Iterator[int]:
+    """
+    Yields image_ids.
+    0 based index slicing, start inclusive, stop exclusive.
+    Iterates from start to end if stop is None.
+    """
+    # convert to path object
+    pilot_path = Path(pilot_path)
+
+    # validate slice bounds
+    if start < 0:
+        raise ValueError("start can not be negative")
+    if (stop is not None) and (stop < start):
+        raise ValueError("stop can not be smaller than start")
+
+    # read ids from csv
+    with pilot_path.open("r", encoding="utf-8") as f:
+
+        image_ids = []
+
+        for line in f:
+            # remove trailing spaces
+            stripped_line = line.strip()
+            # remove empty lines
+            if not stripped_line:
+                continue
+            # convert to int
+            image_id = int(stripped_line)
+
+            # add ids to list
+            image_ids.append(image_id)
+
+        # apply slicing
+        image_ids = image_ids[start:stop]
+
+        for image_id in image_ids:
+            yield image_id
+
+
+def iter_id_images_from_pilot(
+    start: int = 0,
+    stop: int | None = None,
+    pilot_path: str | Path = PILOT_IDS_CSV,
+    db_path: str | None = None,
+    policy: str = "skip_and_log",
+) -> Iterator[tuple[int, np.ndarray]]:
+    """
+    Yields pairs of image_id (from pilot csv) and img_array (from db lookup).
+    0 based index slicing, start inclusive, stop exclusive.
+    Iterates from start to end if stop is None.
+    ImageLoadError message includes image_id | path | reason.
+    """
+    # catch wrong input
+    if policy not in {"skip_and_log", "raise"}:
+        raise ValueError("policy must be either skip_and_log or raise")
+
+    # iterate ids from pilot
+    for image_id in iter_ids_pilot(start=start, stop=stop, pilot_path=pilot_path):
+
+        # lookup matching path in db
+        path = get_path_by_id(image_id=image_id, db_path=db_path)
+
+        if path is None:
+
+            # log on error
+            if policy == "skip_and_log":
+                msg = f"{image_id} | <no path> | not present in database"
+                log.error(msg)
+                continue
+
+            # raise on error
+            elif policy == "raise":
+                msg = f"{image_id} | <no path> | not present in database"
+                raise ValueError(msg)
+
+        else:
+            # load image
+            try:
+                img_array = load_rgb(path)
+
+            except ImageLoadError as e:
+
+                # log on error
+                if policy == "skip_and_log":
+                    loader_msg = str(e)
+                    msg = f"{image_id} | {loader_msg}"
+                    log.error(msg)
+                    continue
+
+                # raise on error
+                elif policy == "raise":
+                    loader_msg = str(e)
+                    msg = f"{image_id} | {loader_msg}"
+                    raise ImageLoadError(msg) from e
+
+            yield image_id, img_array

--- a/src/image_recommender/io/img_iterator.py
+++ b/src/image_recommender/io/img_iterator.py
@@ -1,0 +1,54 @@
+from collections.abc import Iterator
+
+import numpy as np
+
+from image_recommender.db.connector import iter_id_paths
+from image_recommender.io.img_loader import load_rgb
+from image_recommender.util.errors import ImageLoadError
+from image_recommender.util.logs import get_logger
+
+# module level logger
+log = get_logger(__name__)  # pass modules name
+
+
+# for full runs
+def iter_id_images_from_db(
+    start: int = 0,
+    stop: int | None = None,
+    db_path: str | None = None,
+    policy: str = "skip_and_log",
+) -> Iterator[tuple[int, np.ndarray]]:
+    """
+    Yields pairs of image_id and img_array.
+    Ordered by image_id.
+    0 based index slicing, start inclusive, stop exclusive.
+    Iterates from start to end if stop is None.
+    ImageLoadError message includes image_id | path | reason.
+    """
+    # catch wrong input
+    if policy not in {"skip_and_log", "raise"}:
+        raise ValueError("policy must be either skip_and_log or raise")
+
+    # get id, path from db
+    for image_id, path in iter_id_paths(start=start, stop=stop, db_path=db_path):
+
+        try:
+            # load image
+            img_array = load_rgb(path)
+
+        except ImageLoadError as e:
+
+            # log on error
+            if policy == "skip_and_log":
+                loader_msg = str(e)
+                msg = f"{image_id} | {loader_msg}"
+                log.error(msg)
+                continue
+
+            # raise on error
+            elif policy == "raise":
+                loader_msg = str(e)
+                msg = f"{image_id} | {loader_msg}"
+                raise ImageLoadError(msg) from e
+
+        yield image_id, img_array

--- a/src/image_recommender/io/img_loader.py
+++ b/src/image_recommender/io/img_loader.py
@@ -4,10 +4,6 @@ import numpy as np
 from PIL import Image, UnidentifiedImageError
 
 from image_recommender.util.errors import ImageLoadError
-from image_recommender.util.logs import get_logger
-
-# module level logger
-log = get_logger(__name__)  # pass modules name
 
 
 def load_rgb(path: str | Path) -> np.ndarray:
@@ -29,28 +25,23 @@ def load_rgb(path: str | Path) -> np.ndarray:
 
     except FileNotFoundError as e:
         msg = f"{path} | file not found"
-        log.error(msg)
         raise ImageLoadError(msg) from e
 
     except UnidentifiedImageError as e:
         msg = f"{path} | unidentified/unsupported image"
-        log.error(msg)
         raise ImageLoadError(msg) from e
 
     except OSError as e:
         msg = f"{path} | corrupt or unreadable image"
-        log.error(msg)
         raise ImageLoadError(msg) from e
 
     except Exception as e:
         msg = f"{path} | unexpected error: {e.__class__.__name__}"
-        log.error(msg)
         raise ImageLoadError(msg) from e
 
     # validate final shape
     if img_array.ndim != 3 or img_array.shape[2] != 3:
         msg = f"{path} | invalid shape {tuple(img_array.shape)} (expected [H,W,3])"
-        log.error(msg)
         raise ImageLoadError(msg)
 
     return img_array

--- a/tests/db/test_connector.py
+++ b/tests/db/test_connector.py
@@ -95,3 +95,49 @@ def test_count_and_iter_all(tmp_db: str, example_image: dict[str, Any]) -> None:
     ids = list(connector.iter_all_ids(db_path=tmp_db))
 
     assert len(ids) == 5  # Are there five images in the DB (in the list)?
+
+
+# ---------- FULL DB RUN TESTS ------------
+
+
+def test_iter_id_paths(tmp_db: str, example_image: dict[str, Any]) -> None:
+    # add 5 rows to db
+    for i in range(5):
+        img = example_image.copy()
+        img["path"] = f"images/sample_{i}.jpg"  # samples 0-4
+        connector.upsert_image(**img, db_path=tmp_db)
+
+    # check order (by id, ascending)
+    id_paths = list(connector.iter_id_paths(db_path=tmp_db))  # convert to list
+    ids = [id for (id, path) in id_paths]  # extract ids
+    assert ids == sorted(ids)
+
+    # check slicing
+    id_paths_slice = list(connector.iter_id_paths(start=1, stop=3, db_path=tmp_db))
+    assert len(id_paths_slice) == 2
+    paths = [path for (id, path) in id_paths_slice]  # extract paths
+    assert paths == ["images/sample_1.jpg", "images/sample_2.jpg"]
+
+    # check stop = None behavior
+    id_paths_1_to_5 = list(connector.iter_id_paths(start=1, db_path=tmp_db))
+    assert len(id_paths_1_to_5) == 4
+
+    # check start = stop behavior
+    id_path_1 = list(connector.iter_id_paths(start=1, stop=1, db_path=tmp_db))
+    assert len(id_path_1) == 0
+
+    # validate errors get raised
+
+    # start < 0
+    with pytest.raises(ValueError) as excinfo_1:
+        list(connector.iter_id_paths(start=-1, db_path=tmp_db))
+
+    msg = str(excinfo_1.value)
+    assert "start can not be negative" in msg
+
+    # stop < start & not None
+    with pytest.raises(ValueError) as excinfo_2:
+        list(connector.iter_id_paths(start=2, stop=1, db_path=tmp_db))
+
+    msg = str(excinfo_2.value)
+    assert "stop can not be smaller than start" in msg

--- a/tests/io/test_img_iterator.py
+++ b/tests/io/test_img_iterator.py
@@ -1,7 +1,9 @@
+import csv
 import logging
 import os
 import tempfile
 from collections.abc import Generator
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -27,7 +29,16 @@ def tmp_db() -> Generator[str, None, None]:
         os.remove(path)
 
 
-def test_happy_path(tmp_db: str) -> None:
+@pytest.fixture
+# create temporary pilot dir
+def pilot_dir(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+# ---------------------------- Test DB Run ---------------------------------
+
+
+def test_db_happy_path(tmp_db: str) -> None:
     # get list of 3 sample images as path objects
     sample_path_objects = list_samples(root=SAMPLES_DIR, limit=3)
 
@@ -51,7 +62,7 @@ def test_happy_path(tmp_db: str) -> None:
     # get ids and images from db
     happy_pairs = list(mod.iter_id_images_from_db(db_path=tmp_db))
 
-    # check number of images in db
+    # check number of entries
     assert len(happy_pairs) == 3
 
     # check ids are sorted ascending
@@ -67,7 +78,7 @@ def test_happy_path(tmp_db: str) -> None:
         assert img_array.dtype == np.uint8
 
 
-def test_skip_and_log(tmp_db: str, caplog) -> None:
+def test_db_skip_and_log(tmp_db: str, caplog) -> None:
     # get list of 2 sample images as path objects
     sample_path_objects = list_samples(root=SAMPLES_DIR, limit=2)
 
@@ -97,24 +108,23 @@ def test_skip_and_log(tmp_db: str, caplog) -> None:
 
     # get ids and images from db, skip and log
     pairs = list(mod.iter_id_images_from_db(db_path=tmp_db, policy="skip_and_log"))
-    # check number of images in db
+    # check number of entries
     assert len(pairs) == 2
 
     # retrieve logs
-    records = [r for r in caplog.records if r.levelname == "ERROR"]
+    records = [r for r in caplog.records if (r.levelname == "ERROR") and (r.name == mod.__name__)]
     # check only one log was captured
     assert len(records) == 1
-    # check module is included
+    # retrieve message
     rec = records[0]
-    assert str(mod.__name__) == rec.name
+    msg = rec.getMessage()
     # check path is included
-    msg = rec.getMessage()  # retrieve log
     assert "invalid_image.jpg" in msg
     # check reason is included
     assert "file not found" in msg
 
 
-def test_raise(tmp_db: str) -> None:
+def test_db_raise(tmp_db: str) -> None:
     # get list of 2 sample images as path objects
     sample_path_objects = list_samples(root=SAMPLES_DIR, limit=2)
 
@@ -143,6 +153,214 @@ def test_raise(tmp_db: str) -> None:
     with pytest.raises(ImageLoadError) as excinfo:
         # convert to list and return (needed to raise)
         list(mod.iter_id_images_from_db(db_path=tmp_db, policy="raise"))
+
+    msg = str(excinfo.value)
+    # check id is included
+    assert str(bad_id) in msg
+    # check path is included
+    assert "non_existent_image.jpg" in msg
+    # check reason is included
+    assert "file not found" in msg
+
+
+# ---------------------------- Test Pilot Run ---------------------------------
+
+
+def test_iter_ids_pilot(pilot_dir):
+    # add csv file to tmp dir
+    pilot_path = pilot_dir / "ids.csv"
+    with open(pilot_path, "w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        # add 3 valid entries
+        writer.writerow([42])
+        writer.writerow([67])
+        writer.writerow(["11"])
+
+        # add 1 empty line
+        csvfile.write("\n")
+
+    # convert to list
+    pilot_ids = list(mod.iter_ids_pilot(start=1, pilot_path=pilot_path))
+
+    # check number of ids
+    assert len(pilot_ids) == 2
+    # check id order & data type
+    assert pilot_ids == [67, 11]
+
+
+def test_pilot_happy_path(pilot_dir, tmp_db: str) -> None:
+    # get list of 3 sample images as path objects
+    sample_path_objects = list_samples(root=SAMPLES_DIR, limit=3)
+
+    # capture ids from db insertion
+    db_ids = []
+
+    # for each sample
+    for sample in sample_path_objects:
+        # compute absolute path string
+        abs_path = str(sample.resolve())
+
+        # set added_at
+        added_at = "test_img_iterator"
+
+        # get width, height, ext and bytes_
+        with Image.open(sample) as img:
+            width, height = img.size
+            ext: str = sample.suffix.lower()
+            bytes_: int = sample.stat().st_size
+
+            # add entry to temporary db
+            db_ids.append(
+                upsert_image(abs_path, width, height, ext, bytes_, added_at, db_path=tmp_db)
+            )
+
+    # shuffle id order for pilot
+    pilot_ids = list(reversed(db_ids))
+
+    # add csv file to tmp dir
+    pilot_path = pilot_dir / "ids.csv"
+    with open(pilot_path, "w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        # add 3 valid entries
+        for image_id in pilot_ids:
+            writer.writerow([image_id])
+
+        # add 1 empty line
+        csvfile.write("\n")
+
+    # get ids from pilot and images from db
+    happy_pairs = list(mod.iter_id_images_from_pilot(pilot_path=pilot_path, db_path=tmp_db))
+
+    # check number of entries
+    assert len(happy_pairs) == 3
+
+    # check pilots id order is preserved
+    returned_ids = [image_id for image_id, _ in happy_pairs]
+    assert returned_ids == pilot_ids
+
+    for _, image_array in happy_pairs:
+        # check shape of images
+        assert image_array.ndim == 3
+        assert image_array.shape[2] == 3  # RGB channels
+
+        # check type of images
+        assert image_array.dtype == np.uint8
+
+
+def test_pilot_skip_and_log_missing_id(pilot_dir, tmp_db: str, caplog) -> None:
+    # get list of 2 sample images as path objects
+    sample_path_objects = list_samples(root=SAMPLES_DIR, limit=2)
+
+    # capture ids from db insertion
+    db_ids = []
+
+    # for each sample
+    for sample in sample_path_objects:
+        # compute absolute path string
+        abs_path = str(sample.resolve())
+        # set added_at
+        added_at = "test_img_iterator"
+
+        # get width, height, ext and bytes_
+        with Image.open(sample) as img:
+            width, height = img.size
+            ext: str = sample.suffix.lower()
+            bytes_: int = sample.stat().st_size
+
+            # add entry to temporary db
+            db_ids.append(
+                upsert_image(abs_path, width, height, ext, bytes_, added_at, db_path=tmp_db)
+            )
+
+    # generate missing id
+    missing_id = max(db_ids) + 9999
+
+    # add csv file to tmp dir
+    pilot_path = pilot_dir / "ids.csv"
+    with open(pilot_path, "w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        # add 2 valid entries
+        for image_id in db_ids:
+            writer.writerow([image_id])
+
+        # add invalid id
+        writer.writerow([missing_id])
+
+        # add 1 empty line
+        csvfile.write("\n")
+
+    # set logger level
+    caplog.set_level(logging.ERROR)
+
+    # get ids from pilot and images from db, skip and log
+    pairs = list(
+        mod.iter_id_images_from_pilot(pilot_path=pilot_path, db_path=tmp_db, policy="skip_and_log")
+    )
+
+    # check number of entries
+    assert len(pairs) == 2
+
+    # retrieve logs
+    records = [r for r in caplog.records if (r.levelname == "ERROR") and (r.name == mod.__name__)]
+    # check only one log was captured
+    assert len(records) == 1
+    # retrieve message
+    rec = records[0]
+    msg = rec.getMessage()
+    # check id is included
+    assert str(missing_id) in msg
+    # check reason is included
+    assert "not present in database" in msg
+
+
+def test_pilot_raise_load_error(pilot_dir, tmp_db: str) -> None:
+    # get list of 2 sample images as path objects
+    sample_path_objects = list_samples(root=SAMPLES_DIR, limit=2)
+
+    # capture ids from db insertion
+    db_ids = []
+
+    # for each sample
+    for sample in sample_path_objects:
+        # compute absolute path string
+        abs_path = str(sample.resolve())
+        # set added_at
+        added_at = "test_img_iterator"
+
+        # get width, height, ext and bytes_
+        with Image.open(sample) as img:
+            width, height = img.size
+            ext: str = sample.suffix.lower()
+            bytes_: int = sample.stat().st_size
+
+            # add entry to temporary db
+            db_ids.append(
+                upsert_image(abs_path, width, height, ext, bytes_, added_at, db_path=tmp_db)
+            )
+
+    # add invalid entry and capture id
+    bad_id = upsert_image(
+        "/non_existent_image.jpg", 123, 456, ".jpg", 789, "test_img_iterator", db_path=tmp_db
+    )
+
+    # add csv file to tmp dir
+    pilot_path = pilot_dir / "ids.csv"
+    with open(pilot_path, "w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        # add 2 valid entries
+        for image_id in db_ids:
+            writer.writerow([image_id])
+
+        # add bad images id
+        writer.writerow([bad_id])
+
+        # add 1 empty line
+        csvfile.write("\n")
+
+    # re-raise error from img_loader with img_iterator
+    with pytest.raises(ImageLoadError) as excinfo:
+        # convert to list and return (needed to raise)
+        list(mod.iter_id_images_from_pilot(pilot_path=pilot_path, db_path=tmp_db, policy="raise"))
 
     msg = str(excinfo.value)
     # check id is included

--- a/tests/io/test_img_iterator.py
+++ b/tests/io/test_img_iterator.py
@@ -1,0 +1,153 @@
+import logging
+import os
+import tempfile
+from collections.abc import Generator
+
+import numpy as np
+import pytest
+from PIL import Image
+
+import image_recommender.io.img_iterator as mod
+from image_recommender.constants import SAMPLES_DIR
+from image_recommender.db.connector import init_db, upsert_image
+from image_recommender.util.errors import ImageLoadError
+from image_recommender.util.sampler import list_samples
+
+
+@pytest.fixture
+def tmp_db() -> Generator[str, None, None]:
+    """Creates a temporary database to run tests."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    try:
+        init_db(db_path=path)
+        yield path
+    finally:
+        os.remove(path)
+
+
+def test_happy_path(tmp_db: str) -> None:
+    # get list of 3 sample images as path objects
+    sample_path_objects = list_samples(root=SAMPLES_DIR, limit=3)
+
+    # for each sample
+    for sample in sample_path_objects:
+        # compute absolute path string
+        abs_path = str(sample.resolve())
+
+        # set added_at
+        added_at = "test_img_iterator"
+
+        # get width, height, ext and bytes_
+        with Image.open(sample) as img:
+            width, height = img.size
+            ext: str = sample.suffix.lower()
+            bytes_: int = sample.stat().st_size
+
+            # add entry to temporary db
+            upsert_image(abs_path, width, height, ext, bytes_, added_at, db_path=tmp_db)
+
+    # get ids and images from db
+    happy_pairs = list(mod.iter_id_images_from_db(db_path=tmp_db))
+
+    # check number of images in db
+    assert len(happy_pairs) == 3
+
+    # check ids are sorted ascending
+    happy_ids = [image_id for image_id, _ in happy_pairs]
+    assert happy_ids == sorted(happy_ids)
+
+    for _, img_array in happy_pairs:
+        # check shape of images
+        assert img_array.ndim == 3
+        assert img_array.shape[2] == 3  # RGB channels
+
+        # check type of images
+        assert img_array.dtype == np.uint8
+
+
+def test_skip_and_log(tmp_db: str, caplog) -> None:
+    # get list of 2 sample images as path objects
+    sample_path_objects = list_samples(root=SAMPLES_DIR, limit=2)
+
+    # for each sample
+    for sample in sample_path_objects:
+        # compute absolute path string
+        abs_path = str(sample.resolve())
+        # set added_at
+        added_at = "test_img_iterator"
+
+        # get width, height, ext and bytes_
+        with Image.open(sample) as img:
+            width, height = img.size
+            ext: str = sample.suffix.lower()
+            bytes_: int = sample.stat().st_size
+
+            # add entry to temporary db
+            upsert_image(abs_path, width, height, ext, bytes_, added_at, db_path=tmp_db)
+
+    # add invalid entry
+    upsert_image(
+        "bad/invalid_image.jpg", 123, 456, ".jpg", 789, "test_img_iterator", db_path=tmp_db
+    )
+
+    # set logger level
+    caplog.set_level(logging.ERROR)
+
+    # get ids and images from db, skip and log
+    pairs = list(mod.iter_id_images_from_db(db_path=tmp_db, policy="skip_and_log"))
+    # check number of images in db
+    assert len(pairs) == 2
+
+    # retrieve logs
+    records = [r for r in caplog.records if r.levelname == "ERROR"]
+    # check only one log was captured
+    assert len(records) == 1
+    # check module is included
+    rec = records[0]
+    assert str(mod.__name__) == rec.name
+    # check path is included
+    msg = rec.getMessage()  # retrieve log
+    assert "invalid_image.jpg" in msg
+    # check reason is included
+    assert "file not found" in msg
+
+
+def test_raise(tmp_db: str) -> None:
+    # get list of 2 sample images as path objects
+    sample_path_objects = list_samples(root=SAMPLES_DIR, limit=2)
+
+    # for each sample
+    for sample in sample_path_objects:
+        # compute absolute path string
+        abs_path = str(sample.resolve())
+        # set added_at
+        added_at = "test_img_iterator"
+
+        # get width, height, ext and bytes_
+        with Image.open(sample) as img:
+            width, height = img.size
+            ext: str = sample.suffix.lower()
+            bytes_: int = sample.stat().st_size
+
+            # add entry to temporary db
+            upsert_image(abs_path, width, height, ext, bytes_, added_at, db_path=tmp_db)
+
+    # add invalid entry and capture id
+    bad_id = upsert_image(
+        "/non_existent_image.jpg", 123, 456, ".jpg", 789, "test_img_iterator", db_path=tmp_db
+    )
+
+    # re-raise error from img_loader with img_iterator
+    with pytest.raises(ImageLoadError) as excinfo:
+        # convert to list and return (needed to raise)
+        list(mod.iter_id_images_from_db(db_path=tmp_db, policy="raise"))
+
+    msg = str(excinfo.value)
+    # check id is included
+    assert str(bad_id) in msg
+    # check path is included
+    assert "non_existent_image.jpg" in msg
+    # check reason is included
+    assert "file not found" in msg

--- a/tests/io/test_img_loader.py
+++ b/tests/io/test_img_loader.py
@@ -1,9 +1,8 @@
-import logging
 from pathlib import Path
 
 import numpy as np
 import pytest
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 
 import image_recommender.io.img_loader as mod
 from image_recommender.util.errors import ImageLoadError
@@ -39,22 +38,16 @@ def test_gray_to_rgb(samples_dir):
     assert rgb_array.dtype == np.uint8
 
 
-def test_non_img(samples_dir, caplog):
-    caplog.set_level(logging.ERROR)
+def test_non_img(samples_dir):
     non_img_path = samples_dir / "non_img.txt"
     non_img_path.write_text("test")
     # raise custom error (wraps PIL errors)
-    with pytest.raises(ImageLoadError):
+    with pytest.raises(ImageLoadError) as excinfo:
         mod.load_rgb(non_img_path)
-    # retrieve logs
-    records = [r for r in caplog.records if r.levelname == "ERROR"]
-    # only one log captured
-    assert len(records) == 1
-    # module included
-    rec = records[0]
-    assert str(mod.__name__) == rec.name
     # path included
-    msg = rec.getMessage()  # retrieve log
+    msg = str(excinfo.value)
     assert str(non_img_path) in msg
     # reason included
     assert "unidentified/unsupported image" in msg
+    # original cause included
+    assert isinstance(excinfo.value.__cause__, UnidentifiedImageError)


### PR DESCRIPTION
## Linked Issue
<!-- REQUIRED: link the primary issue (e.g. "Closes #123") -->
Closes #36 


## Summary (Delta vs Issue)
<!-- What changed compared to the issue plan? If exactly as planned, say "Matches issue." -->
- added db connector helper for (image_id, path) iteration with start/stop slicing
- adjusted image loader behavior so it raises ImageLoadError without ERROR logging (iterator owns logging)


## Scope
<!-- Short bullets of what this PR actually changes/adds. No future work. -->
- Iterator
    - db mode: stream (image_id, img) from DB-ordered (image_id, path) slice
    - pilot mode: stream (image_id, img) from pilot IDs (file order) slice, via DB id->path lookup
      
    - Error policy behavior
	    - skip_and_log: log one ERROR with id + path + reason, continue
	    - raise: fail fast; load failure preserves exception chaining
	    - missing mapping handled explicitly (id not present in DB)
    
- DB connector additions
    - iterator/helper to yield (image_id, path) ordered by image_id with start/stop (0-based, stop-exclusive, stop=None)
    - existing get_path_by_id used for pilot mode lookup
    
- Image loader adjustment
    - loader raises ImageLoadError (with cause chaining), removed ERROR logging (prevents double logging)


## How Tested / Evidence
<!-- What proves it works? Paste commands & outcomes; attach logs/screens if useful. -->
- pytest (all tests pass)
    
- Notes:
    - db mode tests: happy path, slicing, skip_and_log logging once, raise mode surfaces ImageLoadError
    - pilot mode tests: pilot order preserved, skip_and_log for missing ID, raise on load failure (bad path)
    
    
## Risk & Rollback (optional)
<!-- Any side effects? How to revert safely if needed. -->

## Notes for Reviewers (optional)
<!-- Call out tricky parts, follow-up PRs, or decisions deviating from the issue. -->
- Logging ownership: iterator logs (includes image_id), loader only raises
- Pilot file format: one integer ID per line, empty lines ignored

## Checklist
- [x] Labels set (area, block, priority)
- [x] CI passes (lint-format, tests, cli-smoke)
- [x] Tests updated/added (only for what this PR changes)
