### PR TITLE
Feature/issue 38/atomic file writes

### DIFF
--- a/src/image_recommender/util/fsatomic.py
+++ b/src/image_recommender/util/fsatomic.py
@@ -1,0 +1,29 @@
+import os
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import BinaryIO
+
+
+def write_tmp_then_rename(final: Path | str, write_fn: Callable[[BinaryIO], None]) -> None:
+    """
+    Write temporary file to same dir as final, using a callable, then atomic replace.
+    """
+    # convert to path object
+    final = Path(final)
+    # check parent dir exists
+    parent_dir = final.parent
+    if not parent_dir.exists():
+        raise FileNotFoundError("Parent directory does not exist.")
+    # create named temporary file in final files parent dir
+    with tempfile.NamedTemporaryFile(
+        mode="wb", prefix=final.name + ".tmp-", dir=parent_dir, delete=False
+    ) as tmp_file:
+        # capture temporary files path and convert
+        tmp_path = Path(tmp_file.name)
+
+        # pass open file handler to write function
+        write_fn(tmp_file)
+
+    # atomic replace
+    os.replace(tmp_path, final)

--- a/src/image_recommender/util/fsatomic.py
+++ b/src/image_recommender/util/fsatomic.py
@@ -7,8 +7,11 @@ from typing import BinaryIO
 
 def write_tmp_then_rename(final: Path | str, write_fn: Callable[[BinaryIO], None]) -> None:
     """
-    Write temporary file to same dir as final, using a callable, then atomic replace.
+    Write to named temporary file in same directory as final using a callable,
+    flush & fsync, then atomically replace final with tmp file contents.
+    Best-effort: fsync parent directory.
     """
+
     # convert to path object
     final = Path(final)
     # check parent dir exists
@@ -25,5 +28,28 @@ def write_tmp_then_rename(final: Path | str, write_fn: Callable[[BinaryIO], None
         # pass open file handler to write function
         write_fn(tmp_file)
 
+        # flush bytes in pythons buffer to os
+        tmp_file.flush()
+
+        # fsync: request os to sync file contents to disk
+        os.fsync(tmp_file.fileno())
+
     # atomic replace
     os.replace(tmp_path, final)
+
+    # best effort: fsync parent dir
+    try:
+        # open parent dir file descriptor
+        dir_fd = os.open(str(parent_dir), os.O_RDONLY)
+
+        try:
+            # fsync: request os to sync dir contents to disk
+            os.fsync(dir_fd)
+
+        finally:
+            # close file descriptor
+            os.close(dir_fd)
+
+    except (OSError, TypeError, AttributeError):
+        # fail silently
+        pass

--- a/tests/util/test_fsatomic.py
+++ b/tests/util/test_fsatomic.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from typing import BinaryIO
+
+from image_recommender.util.fsatomic import write_tmp_then_rename
+
+TEST_BYTES = bytes([74, 65, 73, 74])
+
+
+def _write_bytes(f: BinaryIO) -> None:
+    # test write function
+    f.write(TEST_BYTES)
+
+
+def test_happy_path(tmp_path: Path) -> None:
+    # compose final path
+    happy_path = tmp_path / "test_shard.bin"
+    write_tmp_then_rename(final=happy_path, write_fn=_write_bytes)
+    # convert to list
+    happy_entries = list(tmp_path.iterdir())
+    # check tmp file was replaced and final file was created
+    assert len(happy_entries) == 1
+    # check final file was created
+    assert happy_entries[0].name == "test_shard.bin"
+    # check final file contains expected bytes
+    assert happy_path.read_bytes() == TEST_BYTES

--- a/tests/util/test_fsatomic.py
+++ b/tests/util/test_fsatomic.py
@@ -1,25 +1,60 @@
 from pathlib import Path
 from typing import BinaryIO
 
+import pytest
+
 from image_recommender.util.fsatomic import write_tmp_then_rename
 
 TEST_BYTES = bytes([74, 65, 73, 74])
 
 
 def _write_bytes(f: BinaryIO) -> None:
-    # test write function
+    """
+    Writes deterministic payload for test.
+    """
     f.write(TEST_BYTES)
+
+
+def _write_error(f: BinaryIO) -> None:
+    """
+    Writes partial data, then raises to simulate write failure.
+    """
+    f.write(bytes([11, 11]))
+    raise RuntimeError("Intentional failure.")
 
 
 def test_happy_path(tmp_path: Path) -> None:
     # compose final path
-    happy_path = tmp_path / "test_shard.bin"
+    happy_path = tmp_path / "happy_shard.bin"
+    # write bytes
     write_tmp_then_rename(final=happy_path, write_fn=_write_bytes)
     # convert to list
     happy_entries = list(tmp_path.iterdir())
-    # check tmp file was replaced and final file was created
+    # check only one file exists (no tmp leftover)
     assert len(happy_entries) == 1
     # check final file was created
-    assert happy_entries[0].name == "test_shard.bin"
+    assert happy_entries[0].name == "happy_shard.bin"
     # check final file contains expected bytes
     assert happy_path.read_bytes() == TEST_BYTES
+
+
+def test_no_final_on_failing_w(tmp_path: Path) -> None:
+    # compose final path
+    missing_path = tmp_path / "missing_shard.bin"
+    # fail write
+    with pytest.raises(RuntimeError):
+        write_tmp_then_rename(final=missing_path, write_fn=_write_error)
+    # check final was not created
+    assert missing_path.exists() is False
+
+
+def test_no_updated_final_on_failing_w(tmp_path: Path) -> None:
+    # compose final path
+    old_path = tmp_path / "old_shard.bin"
+    # write bytes
+    write_tmp_then_rename(final=old_path, write_fn=_write_bytes)
+    # fail second write
+    with pytest.raises(RuntimeError):
+        write_tmp_then_rename(final=old_path, write_fn=_write_error)
+    # check final was not updated on failed write
+    assert old_path.read_bytes() == TEST_BYTES


### PR DESCRIPTION
## Linked Issue
<!-- REQUIRED: link the primary issue (e.g. "Closes #123") -->
Closes #38 

## Summary (Delta vs Issue)
<!-- What changed compared to the issue plan? If exactly as planned, say "Matches issue." -->
matches issue

## Scope
<!-- Short bullets of what this PR actually changes/adds. No future work. -->
- util/fsatomic.write_tmp_then_rename:
  - create named temp file in same directory as final
  - delegate write via callable using open binary file handle
  - flush + fsync temp file before publish
  - publish via atomic replace
  - best-effort: fsync parent directory after publish (no failure on unsupported behavior)

- tests/util/test_fsatomic:
  - test_happy_path: final created with expected bytes, no temp leftover after publish
  - test_no_final_on_failing_w: failing writer does not create final when absent
  - test_no_updated_final_on_failing_w: failing writer does not modify existing final on failure

## How Tested / Evidence
<!-- What proves it works? Paste commands & outcomes; attach logs/screens if useful. -->
pytest (all tests pass)

## Risk & Rollback (optional)
<!-- Any side effects? How to revert safely if needed. -->

## Notes for Reviewers (optional)
<!-- Call out tricky parts, follow-up PRs, or decisions deviating from the issue. -->
IMPORTANT: Please do not merge before #37, since the commits are stacked.
Best-effort dir fsync may no-op or raise on some platforms, fails silently on purpose.

## Checklist
- [x] Labels set (area, block, priority)
- [x] CI passes (lint-format, tests, cli-smoke)
- [x] Tests updated/added (only for what this PR changes)
