### PR TITLE
feature/issue 42/atomic shard write

### DIFF
--- a/src/image_recommender/features/storage.py
+++ b/src/image_recommender/features/storage.py
@@ -1,4 +1,11 @@
+import json
+from collections.abc import Sequence
 from pathlib import Path
+from typing import BinaryIO
+
+import numpy as np
+
+from image_recommender.util.fsatomic import write_tmp_then_rename
 
 VERSION = 1
 
@@ -35,3 +42,104 @@ def shard_paths(run_dir: Path | str, feature_type: str, shard_id: int) -> tuple[
     meta_path = shard_dir / "meta.json"
 
     return features_path, ids_path, meta_path
+
+
+def _validate_shard_inputs(
+    feature_type: str, features: np.ndarray, ids: Sequence[int], meta: dict[str, object]
+) -> None:
+    # check features dimensions
+    if features.ndim != 2:
+        raise ValueError("Feature array has wrong dimensions.")
+
+    # check length matches
+    if len(ids) != features.shape[0]:
+        raise ValueError("The number of features and ids is mismatched.")
+
+    # check meta keys
+    if set(meta.keys()) != REQUIRED_META_KEYS:
+        raise ValueError("The meta keys are incorrect.")
+
+    # check meta version
+    if meta["version"] != VERSION:
+        raise ValueError("Meta version mismatch.")
+
+    # check consistency with data
+    if meta["feature_dim"] != features.shape[1]:
+        raise ValueError("Metadata and data feature dimensions are mismatched.")
+    if meta["feature_dtype"] != str(features.dtype):
+        raise ValueError("Metadata and data type are mismatched.")
+    if meta["shard_size"] != features.shape[0]:
+        raise ValueError("Metadata and data size are mismatched.")
+    if meta["feature_type"] != feature_type:
+        raise ValueError("Metadata and data feature type are mismatched.")
+
+
+def _write_meta_json_atomic(meta_path: Path, meta: dict[str, object]) -> None:
+    # build json string from meta dict
+    json_meta = json.dumps(meta, indent=2, sort_keys=True)
+    # encode to bytes
+    json_meta = json_meta.encode("utf-8")
+
+    # internal helper: write to file in binary
+    def write_meta(f: BinaryIO) -> None:
+        f.write(json_meta)
+
+    # atomically write meta
+    write_tmp_then_rename(final=meta_path, write_fn=write_meta)
+
+
+def _write_ids_npy_atomic(ids_path: Path, ids: Sequence[int]) -> None:
+    # convert to array
+    ids_arr = np.asarray(ids, dtype=np.int64)
+    # check its 1D
+    if ids_arr.ndim != 1:
+        raise ValueError("Ids must be a 1D array.")
+
+    # internal helper: write to file in binary
+    def write_ids(f: BinaryIO) -> None:
+        # save array to file handle
+        np.save(f, ids_arr)
+
+    # atomically write ids
+    write_tmp_then_rename(final=ids_path, write_fn=write_ids)
+
+
+def _write_features_npy_atomic(features_path: Path, features: np.ndarray) -> None:
+    # check array is 2D
+    if features.ndim != 2:
+        raise ValueError("Features must be a 2D array.")
+    # ensure array is C-contiguous
+    if not features.flags["C_CONTIGUOUS"]:
+        features = np.ascontiguousarray(features)
+
+    # internal helper: write file in binary
+    def write_features(f: BinaryIO) -> None:
+        # save array to file handle
+        np.save(f, features)
+
+    # atomically write features
+    write_tmp_then_rename(final=features_path, write_fn=write_features)
+
+
+def write_shard_atomic(
+    run_dir: Path,
+    shard_id: int,
+    feature_type: str,
+    features: np.ndarray,
+    ids: Sequence[int],
+    meta: dict[str, object],
+) -> None:
+    # validate
+    _validate_shard_inputs(feature_type=feature_type, features=features, ids=ids, meta=meta)
+    # create artifact paths
+    features_path, ids_path, meta_path = shard_paths(
+        run_dir=run_dir, feature_type=feature_type, shard_id=shard_id
+    )
+    # ensure shard dir exists
+    features_path.parent.mkdir(parents=True, exist_ok=True)
+    # write features
+    _write_features_npy_atomic(features_path=features_path, features=features)
+    # write ids
+    _write_ids_npy_atomic(ids_path=ids_path, ids=ids)
+    # write meta
+    _write_meta_json_atomic(meta_path=meta_path, meta=meta)

--- a/tests/features/test_storage.py
+++ b/tests/features/test_storage.py
@@ -1,6 +1,19 @@
+import json
 from pathlib import Path
 
-from image_recommender.features.storage import REQUIRED_META_KEYS, VERSION, shard_paths
+import numpy as np
+import pytest
+
+from image_recommender.features.storage import (
+    REQUIRED_META_KEYS,
+    VERSION,
+    _validate_shard_inputs,
+    _write_features_npy_atomic,
+    _write_ids_npy_atomic,
+    _write_meta_json_atomic,
+    shard_paths,
+    write_shard_atomic,
+)
 
 
 def test_shard_paths() -> None:
@@ -33,3 +46,121 @@ def test_constants() -> None:
         "created_at",
         "version",
     }
+
+
+def test_validate_shard_inputs_raises_on_id_count_mismatch() -> None:
+    # create small 2D test array
+    test_array = np.array([[6, 7], [7, 6]])
+    # create longer ids list
+    mismatched_ids = [15, 2, 23, 42, 5]
+    # create metadata
+    metadata_placeholder = {
+        "feature_type": "hsv",
+        "feature_dim": 2,
+        "feature_dtype": str(test_array.dtype),
+        "shard_size": 2,
+        "created_at": "2026-01-12T00:00:00Z",
+        "version": VERSION,
+    }
+    # check mismatch is caught
+    with pytest.raises(ValueError) as exc_info:
+        _validate_shard_inputs(
+            feature_type="hsv", features=test_array, ids=mismatched_ids, meta=metadata_placeholder
+        )
+    assert str(exc_info.value) == "The number of features and ids is mismatched."
+
+
+def test_write_meta_json_atomic(tmp_path) -> None:
+    # get meta path using helper
+    tmp_meta_path = shard_paths(run_dir=tmp_path, feature_type="hsv", shard_id=9)[2]
+    # create parent dir
+    tmp_meta_path.parent.mkdir(parents=True, exist_ok=True)
+    # create metadata
+    test_metadata = {
+        "feature_type": "hsv",
+        "feature_dim": 2,
+        "feature_dtype": "float32",
+        "shard_size": 2,
+        "created_at": "2026-01-12T00:00:00Z",
+        "version": VERSION,
+    }
+    # write metadata
+    _write_meta_json_atomic(meta_path=tmp_meta_path, meta=test_metadata)
+    # check path exists
+    assert tmp_meta_path.exists()
+    # check data matches meta
+    text = tmp_meta_path.read_text(encoding="utf-8")
+    data = json.loads(text)
+    assert data == test_metadata
+
+
+def test_write_ids_npy_atomic(tmp_path) -> None:
+    # get ids path using helper
+    tmp_ids_path = shard_paths(run_dir=tmp_path, feature_type="embedding", shard_id=5)[1]
+    # create parent dir
+    tmp_ids_path.parent.mkdir(parents=True, exist_ok=True)
+    # create ids
+    test_ids = [4, 90, 3]
+    # write ids
+    _write_ids_npy_atomic(ids_path=tmp_ids_path, ids=test_ids)
+    # check path exists
+    assert tmp_ids_path.exists()
+    # check data matches meta
+    data = np.load(tmp_ids_path)
+    assert data.tolist() == test_ids
+
+
+def test_write_features_npy_atomic(tmp_path) -> None:
+    # get features path using helper
+    tmp_features_path = shard_paths(run_dir=tmp_path, feature_type="hsv", shard_id=41)[0]
+    # create parent dir
+    tmp_features_path.parent.mkdir(parents=True, exist_ok=True)
+    # create base array
+    base_array = np.array([[42, 27, 36, 95], [13, 56, 23, 68]])
+    # create non-contiguous view
+    test_features = base_array[:, ::2]  # columns 0 and 2
+    assert test_features.flags["C_CONTIGUOUS"] is False
+    # write features
+    _write_features_npy_atomic(features_path=tmp_features_path, features=test_features)
+    # check path exists
+    assert tmp_features_path.exists()
+    # check data matches meta
+    data = np.load(tmp_features_path)
+    assert data.tolist() == test_features.tolist()
+
+
+def test_write_shard_happy_path(tmp_path) -> None:
+    # get artifact paths
+    tmp_features_path, tmp_ids_path, tmp_meta_path = shard_paths(
+        run_dir=tmp_path, feature_type="embedding", shard_id=50
+    )
+    # create features
+    test_features = np.array([[1, 2], [3, 4]], dtype=np.float32)
+    # create ids
+    test_ids = [1, 3]
+    # create meta
+    test_meta = {
+        "feature_type": "embedding",
+        "feature_dim": 2,
+        "feature_dtype": "float32",
+        "shard_size": 2,
+        "created_at": "2026-01-12T00:00:00Z",
+        "version": VERSION,
+    }
+    # write shard
+    write_shard_atomic(
+        run_dir=tmp_path,
+        shard_id=50,
+        feature_type="embedding",
+        features=test_features,
+        ids=test_ids,
+        meta=test_meta,
+    )
+    # check artifact paths
+    assert tmp_features_path.exists()
+    assert tmp_ids_path.exists()
+    assert tmp_meta_path.exists()
+    # verify contents
+    assert np.load(tmp_ids_path).tolist() == test_ids
+    assert np.load(tmp_features_path).tolist() == test_features.tolist()
+    assert json.loads(tmp_meta_path.read_text("utf-8")) == test_meta


### PR DESCRIPTION
## Linked Issue
<!-- REQUIRED: link the primary issue (e.g. "Closes #123") -->
Closes #42 

## Summary (Delta vs Issue)
<!-- What changed compared to the issue plan? If exactly as planned, say "Matches issue." -->
Matches issue.

## Scope
<!-- Short bullets of what this PR actually changes/adds. No future work. -->
- Shard input validation helper enforcing strict meta schema, version, and data consistency (dim/dtype/shard_size/type)
- Atomic shard artifact writers:
  - meta.json (stable encoding)
  - ids.npy (1D int array)
  - features.npy (2D array, made C-contiguous)
- write_shard_atomic to create shard directory and persist all artifacts

- Unit tests covering path layout, schema constants, validation error case, per-artifact atomic writes, and shard happy path

## How Tested / Evidence
<!-- What proves it works? Paste commands & outcomes; attach logs/screens if useful. -->
-  pytest (all tests pass)

## Risk & Rollback (optional)
<!-- Any side effects? How to revert safely if needed. -->

## Notes for Reviewers (optional)
<!-- Call out tricky parts, follow-up PRs, or decisions deviating from the issue. -->

## Checklist
- [x] Labels set (area, block, priority)
- [x] CI passes (lint-format, tests, cli-smoke)
- [x] Tests updated/added (only for what this PR changes)
