### PR TITLE
Feature/issue 44/shard math

### DIFF
--- a/src/image_recommender/util/shard_math.py
+++ b/src/image_recommender/util/shard_math.py
@@ -1,0 +1,24 @@
+def compute_range(items: int, parts: int, idx: int) -> tuple[int, int]:
+    """
+    Returns range of a part index (idx).
+    Output is [start, stop) within [0, items). Empty ranges allowed when items < parts.
+    Contiguous coverage, part lengths differ by at most 1.
+    """
+    # validate inputs
+    if items < 0:
+        raise ValueError("Items must be >= 0.")
+    if parts <= 0:
+        raise ValueError("Parts must be >= 1.")
+    if idx < 0 or idx >= parts:
+        raise ValueError("Index must be in [0, parts).")
+    # base length of parts
+    base = items // parts
+    # number of parts larger by 1
+    remainder = items % parts
+    # calculate length of part based on index
+    length = base + 1 if idx < remainder else base
+    # calculate range
+    start = idx * base + min(idx, remainder)
+    stop = start + length
+
+    return start, stop

--- a/tests/util/test_shard_math.py
+++ b/tests/util/test_shard_math.py
@@ -1,3 +1,5 @@
+import pytest
+
 from image_recommender.util.shard_math import compute_range
 
 
@@ -39,3 +41,21 @@ def test_shard_math_edge_cases() -> None:
 
     # items not divisible by parts
     _assert_partition_invariants(items=10, parts=4)
+
+
+def test_shard_math_bad_inputs() -> None:
+    # items < 0
+    with pytest.raises(ValueError, match=r">= 0"):
+        compute_range(items=-1, parts=3, idx=2)
+
+    # parts = 0
+    with pytest.raises(ValueError, match=r">= 1"):
+        compute_range(items=10, parts=0, idx=2)
+
+    # idx < 0
+    with pytest.raises(ValueError, match=r"\[0, parts\)"):
+        compute_range(items=10, parts=2, idx=-2)
+
+    # idx = parts
+    with pytest.raises(ValueError, match=r"\[0, parts\)"):
+        compute_range(items=10, parts=2, idx=2)

--- a/tests/util/test_shard_math.py
+++ b/tests/util/test_shard_math.py
@@ -1,10 +1,7 @@
 from image_recommender.util.shard_math import compute_range
 
 
-def test_shard_math_balanced_partition() -> None:
-    # define inputs
-    items = 10
-    parts = 4
+def _assert_partition_invariants(items: int, parts: int) -> None:
     # build list of ranges
     ranges = [compute_range(items=items, parts=parts, idx=i) for i in range(parts)]
     # split start and stop values
@@ -23,3 +20,22 @@ def test_shard_math_balanced_partition() -> None:
     assert starts[0] == 0
     assert stops[-1] == items
     assert sum(sizes) == items
+
+
+def test_shard_math_happy() -> None:
+    # ranges are contiguous, cover all, sizes differ by <= 1
+    _assert_partition_invariants(items=1000, parts=4)
+
+
+def test_shard_math_edge_cases() -> None:
+    # items=0
+    _assert_partition_invariants(items=0, parts=3)
+
+    # parts=1
+    _assert_partition_invariants(items=6, parts=1)
+
+    # items < parts
+    _assert_partition_invariants(items=2, parts=5)
+
+    # items not divisible by parts
+    _assert_partition_invariants(items=10, parts=4)

--- a/tests/util/test_shard_math.py
+++ b/tests/util/test_shard_math.py
@@ -1,0 +1,25 @@
+from image_recommender.util.shard_math import compute_range
+
+
+def test_shard_math_balanced_partition() -> None:
+    # define inputs
+    items = 10
+    parts = 4
+    # build list of ranges
+    ranges = [compute_range(items=items, parts=parts, idx=i) for i in range(parts)]
+    # split start and stop values
+    starts = [start for start, _ in ranges]
+    stops = [stop for _, stop in ranges]
+    # check valid bounds
+    for i in range(len(ranges)):
+        assert 0 <= starts[i] <= stops[i] <= items
+    # check contiguity
+    for i in range(len(ranges) - 1):
+        assert stops[i] == starts[i + 1]
+    # check part sizes
+    sizes = [(stop - start) for start, stop in ranges]
+    assert max(sizes) - min(sizes) <= 1
+    # check full coverage
+    assert starts[0] == 0
+    assert stops[-1] == items
+    assert sum(sizes) == items


### PR DESCRIPTION
## Linked Issue
<!-- REQUIRED: link the primary issue (e.g. "Closes #123") -->
Closes #44 

## Summary (Delta vs Issue)
<!-- What changed compared to the issue plan? If exactly as planned, say "Matches issue." -->
Matches issue.

## Scope
<!-- Short bullets of what this PR actually changes/adds. No future work. -->
- Deterministic shard range utility compute_range(items, parts, idx) 
  - 0-based, stop-exclusive, balanced part sizes, empty ranges allowed
- Test coverage for shard math 
  - including edge cases and bad-input validation

## How Tested / Evidence
<!-- What proves it works? Paste commands & outcomes; attach logs/screens if useful. -->
-  pytest (all tests pass)
- Notes: Tests assert partition invariants (bounds, contiguity, full coverage, size diff <= 1, sum(sizes)=items) for items=1000, parts=4 plus edge cases (items=0, parts=1, items < parts, items not divisible by parts) and bad inputs (ValueError + message match)

## Risk & Rollback (optional)
<!-- Any side effects? How to revert safely if needed. -->

## Notes for Reviewers (optional)
<!-- Call out tricky parts, follow-up PRs, or decisions deviating from the issue. -->

## Checklist
- [x] Labels set (area, block, priority)
- [x] CI passes (lint-format, tests, cli-smoke)
- [x] Tests updated/added (only for what this PR changes)
