### PR TITLE
feature/issue 46/completion markers pending

### DIFF
--- a/src/image_recommender/features/storage.py
+++ b/src/image_recommender/features/storage.py
@@ -171,3 +171,22 @@ def mark_success(run_dir: Path | str, feature_type: str, shard_id: int) -> None:
     # idempotent create
     if not marker_path.exists():
         marker_path.touch()
+
+
+def list_pending(run_dir: Path | str, feature_type: str, n_shards: int) -> list[int]:
+    # validate inputs
+    if n_shards < 0:
+        raise ValueError("Number of shards must be >= 0.")
+    run_dir = Path(run_dir)
+    if not run_dir.is_dir():
+        raise ValueError(f"{run_dir} is missing, or not a directory.")
+    # pending shards
+    pending_shard_ids = []
+    # compute marker paths
+    for idx in range(n_shards):
+        marker_path = success_marker_path(run_dir=run_dir, feature_type=feature_type, shard_id=idx)
+        # add idx with missing marker
+        if not marker_path.exists():
+            pending_shard_ids.append(idx)
+
+    return pending_shard_ids

--- a/src/image_recommender/features/storage.py
+++ b/src/image_recommender/features/storage.py
@@ -19,6 +19,15 @@ REQUIRED_META_KEYS = {
 }
 
 
+def shard_dir(run_dir: Path | str, feature_type: str, shard_id: int) -> Path:
+    # convert to path
+    run_dir = Path(run_dir)
+    # build shard directory
+    shard_dir = run_dir / feature_type / f"shard_{shard_id:04d}"  # 4 digit zero padding
+
+    return shard_dir
+
+
 def shard_paths(run_dir: Path | str, feature_type: str, shard_id: int) -> tuple[Path, Path, Path]:
     """
     Return artifact paths for one shard in a run directory.
@@ -32,14 +41,12 @@ def shard_paths(run_dir: Path | str, feature_type: str, shard_id: int) -> tuple[
     Notes:
         See required metadata keys in REQUIRED_META_KEYS.
     """
-    # convert to path
-    run_dir = Path(run_dir)
     # build shard directory
-    shard_dir = run_dir / feature_type / f"shard_{shard_id:04d}"  # 4 digit zero padding
+    shard_path = shard_dir(run_dir=run_dir, feature_type=feature_type, shard_id=shard_id)
     # construct artifact paths
-    features_path = shard_dir / "features.npy"
-    ids_path = shard_dir / "ids.npy"
-    meta_path = shard_dir / "meta.json"
+    features_path = shard_path / "features.npy"
+    ids_path = shard_path / "ids.npy"
+    meta_path = shard_path / "meta.json"
 
     return features_path, ids_path, meta_path
 
@@ -143,3 +150,24 @@ def write_shard_atomic(
     _write_ids_npy_atomic(ids_path=ids_path, ids=ids)
     # write meta
     _write_meta_json_atomic(meta_path=meta_path, meta=meta)
+
+
+def success_marker_path(run_dir: Path | str, feature_type: str, shard_id: int) -> Path:
+    # build shard directory
+    shard_path = shard_dir(run_dir=run_dir, feature_type=feature_type, shard_id=shard_id)
+    # build marker path
+    marker_path = shard_path / "_SUCCESS"
+
+    return marker_path
+
+
+def mark_success(run_dir: Path | str, feature_type: str, shard_id: int) -> None:
+    # build marker path
+    marker_path = success_marker_path(run_dir=run_dir, feature_type=feature_type, shard_id=shard_id)
+    # check shard dir exists
+    shard_path = marker_path.parent
+    if not shard_path.is_dir():
+        raise FileNotFoundError(f"{shard_path} is missing, or not a directory.")
+    # idempotent create
+    if not marker_path.exists():
+        marker_path.touch()

--- a/tests/features/test_storage.py
+++ b/tests/features/test_storage.py
@@ -11,6 +11,7 @@ from image_recommender.features.storage import (
     _write_features_npy_atomic,
     _write_ids_npy_atomic,
     _write_meta_json_atomic,
+    list_pending,
     mark_success,
     shard_dir,
     shard_paths,
@@ -180,3 +181,28 @@ def test_idempotent_marker_create(tmp_path: Path) -> None:
     # check success marker exists
     marker_path = success_marker_path(run_dir=tmp_path, feature_type="hsv", shard_id=7)
     assert marker_path.exists()
+
+
+def test_list_pending(tmp_path: Path) -> None:
+    # write 3 shards with success markers
+    for shard_id in range(3):
+        # build shard path
+        test_shard_path = shard_dir(run_dir=tmp_path, feature_type="embedding", shard_id=shard_id)
+        # create shard dir
+        test_shard_path.mkdir(parents=True, exist_ok=True)
+        # mark success
+        mark_success(run_dir=tmp_path, feature_type="embedding", shard_id=shard_id)
+    # collect pending shard ids
+    pending_shard_ids = list_pending(run_dir=tmp_path, feature_type="embedding", n_shards=5)
+    # check expected ids are included
+    assert pending_shard_ids == [3, 4]
+
+
+def test_list_pending_bad_inputs(tmp_path: Path) -> None:
+    # n_shards < 0
+    with pytest.raises(ValueError, match=r">= 0"):
+        list_pending(run_dir=tmp_path, feature_type="embedding", n_shards=-5)
+    # run_dir missing
+    missing = tmp_path / "does_not_exist"
+    with pytest.raises(ValueError, match=r"missing"):
+        list_pending(run_dir=missing, feature_type="hsv", n_shards=8)

--- a/tests/features/test_storage.py
+++ b/tests/features/test_storage.py
@@ -11,7 +11,10 @@ from image_recommender.features.storage import (
     _write_features_npy_atomic,
     _write_ids_npy_atomic,
     _write_meta_json_atomic,
+    mark_success,
+    shard_dir,
     shard_paths,
+    success_marker_path,
     write_shard_atomic,
 )
 
@@ -70,7 +73,7 @@ def test_validate_shard_inputs_raises_on_id_count_mismatch() -> None:
     assert str(exc_info.value) == "The number of features and ids is mismatched."
 
 
-def test_write_meta_json_atomic(tmp_path) -> None:
+def test_write_meta_json_atomic(tmp_path: Path) -> None:
     # get meta path using helper
     tmp_meta_path = shard_paths(run_dir=tmp_path, feature_type="hsv", shard_id=9)[2]
     # create parent dir
@@ -94,7 +97,7 @@ def test_write_meta_json_atomic(tmp_path) -> None:
     assert data == test_metadata
 
 
-def test_write_ids_npy_atomic(tmp_path) -> None:
+def test_write_ids_npy_atomic(tmp_path: Path) -> None:
     # get ids path using helper
     tmp_ids_path = shard_paths(run_dir=tmp_path, feature_type="embedding", shard_id=5)[1]
     # create parent dir
@@ -110,7 +113,7 @@ def test_write_ids_npy_atomic(tmp_path) -> None:
     assert data.tolist() == test_ids
 
 
-def test_write_features_npy_atomic(tmp_path) -> None:
+def test_write_features_npy_atomic(tmp_path: Path) -> None:
     # get features path using helper
     tmp_features_path = shard_paths(run_dir=tmp_path, feature_type="hsv", shard_id=41)[0]
     # create parent dir
@@ -129,7 +132,7 @@ def test_write_features_npy_atomic(tmp_path) -> None:
     assert data.tolist() == test_features.tolist()
 
 
-def test_write_shard_happy_path(tmp_path) -> None:
+def test_write_shard_happy_path(tmp_path: Path) -> None:
     # get artifact paths
     tmp_features_path, tmp_ids_path, tmp_meta_path = shard_paths(
         run_dir=tmp_path, feature_type="embedding", shard_id=50
@@ -164,3 +167,16 @@ def test_write_shard_happy_path(tmp_path) -> None:
     assert np.load(tmp_ids_path).tolist() == test_ids
     assert np.load(tmp_features_path).tolist() == test_features.tolist()
     assert json.loads(tmp_meta_path.read_text("utf-8")) == test_meta
+
+
+def test_idempotent_marker_create(tmp_path: Path) -> None:
+    # build shard path
+    test_shard_path = shard_dir(run_dir=tmp_path, feature_type="hsv", shard_id=7)
+    # create shard dir
+    test_shard_path.mkdir(parents=True, exist_ok=True)
+    # call write success marker twice
+    mark_success(run_dir=tmp_path, feature_type="hsv", shard_id=7)
+    mark_success(run_dir=tmp_path, feature_type="hsv", shard_id=7)
+    # check success marker exists
+    marker_path = success_marker_path(run_dir=tmp_path, feature_type="hsv", shard_id=7)
+    assert marker_path.exists()


### PR DESCRIPTION
## Linked Issue
<!-- REQUIRED: link the primary issue (e.g. "Closes #123") -->
Closes #46 

## Summary (Delta vs Issue)
<!-- What changed compared to the issue plan? If exactly as planned, say "Matches issue." -->
Matches issue.

## Scope
<!-- Short bullets of what this PR actually changes/adds. No future work. -->
- Shard level success marker under run_dir/<feature_type>/shard_{idx:04d}/
- Helpers for shard directory construction, success marker path, and idempotent success marker creation
- Pending shard helper (per feature_type) returns missing shard indices based on success markers
- Tests for marker idempotency, pending detection, and bad-input validation

## How Tested / Evidence
<!-- What proves it works? Paste commands & outcomes; attach logs/screens if useful. -->
- pytest (all tests pass)
- Notes: Covered idempotent marker creation (calling twice does not error), list_pending returns exactly missing indices for a tmp run dir, and bad inputs raise ValueError with expected messages

## Risk & Rollback (optional)
<!-- Any side effects? How to revert safely if needed. -->

## Notes for Reviewers (optional)
<!-- Call out tricky parts, follow-up PRs, or decisions deviating from the issue. -->

## Checklist
- [x] Labels set (area, block, priority)
- [x] CI passes (lint-format, tests, cli-smoke)
- [x] Tests updated/added (only for what this PR changes)