### PR TITLE
feature/issue 48/shard read validate

### DIFF
--- a/src/image_recommender/features/storage.py
+++ b/src/image_recommender/features/storage.py
@@ -6,6 +6,7 @@ from typing import BinaryIO
 import numpy as np
 
 from image_recommender.util.fsatomic import write_tmp_then_rename
+from image_recommender.util.shard_validation import validate_shard
 
 VERSION = 1
 
@@ -49,36 +50,6 @@ def shard_paths(run_dir: Path | str, feature_type: str, shard_id: int) -> tuple[
     meta_path = shard_path / "meta.json"
 
     return features_path, ids_path, meta_path
-
-
-def _validate_shard_inputs(
-    feature_type: str, features: np.ndarray, ids: Sequence[int], meta: dict[str, object]
-) -> None:
-    # check features dimensions
-    if features.ndim != 2:
-        raise ValueError("Feature array has wrong dimensions.")
-
-    # check length matches
-    if len(ids) != features.shape[0]:
-        raise ValueError("The number of features and ids is mismatched.")
-
-    # check meta keys
-    if set(meta.keys()) != REQUIRED_META_KEYS:
-        raise ValueError("The meta keys are incorrect.")
-
-    # check meta version
-    if meta["version"] != VERSION:
-        raise ValueError("Meta version mismatch.")
-
-    # check consistency with data
-    if meta["feature_dim"] != features.shape[1]:
-        raise ValueError("Metadata and data feature dimensions are mismatched.")
-    if meta["feature_dtype"] != str(features.dtype):
-        raise ValueError("Metadata and data type are mismatched.")
-    if meta["shard_size"] != features.shape[0]:
-        raise ValueError("Metadata and data size are mismatched.")
-    if meta["feature_type"] != feature_type:
-        raise ValueError("Metadata and data feature type are mismatched.")
 
 
 def _write_meta_json_atomic(meta_path: Path, meta: dict[str, object]) -> None:
@@ -128,7 +99,7 @@ def _write_features_npy_atomic(features_path: Path, features: np.ndarray) -> Non
     write_tmp_then_rename(final=features_path, write_fn=write_features)
 
 
-def write_shard_atomic(
+def write_validate_shard_atomic(
     run_dir: Path,
     shard_id: int,
     feature_type: str,
@@ -137,7 +108,14 @@ def write_shard_atomic(
     meta: dict[str, object],
 ) -> None:
     # validate
-    _validate_shard_inputs(feature_type=feature_type, features=features, ids=ids, meta=meta)
+    validate_shard(
+        feature_type=feature_type,
+        features=features,
+        ids=ids,
+        meta=meta,
+        required_keys=REQUIRED_META_KEYS,
+        expected_version=VERSION,
+    )
     # create artifact paths
     features_path, ids_path, meta_path = shard_paths(
         run_dir=run_dir, feature_type=feature_type, shard_id=shard_id
@@ -240,8 +218,21 @@ def read_validate_shard(
     # load metadata
     try:
         text = meta_path.read_text(encoding="utf-8")
-        json.loads(text)
+        meta_dict = json.loads(text)
     except Exception as e:
         raise ValueError(f"Failed to load metadata: {e}") from e
+    # check meta is dict
+    if not isinstance(meta_dict, dict):
+        raise ValueError("Metadata is not a dictionary.")
+
+    # validate
+    validate_shard(
+        feature_type=feature_type,
+        features=features_array,
+        ids=ids_list,
+        meta=meta_dict,
+        required_keys=REQUIRED_META_KEYS,
+        expected_version=VERSION,
+    )
 
     return features_array, ids_list

--- a/src/image_recommender/features/storage.py
+++ b/src/image_recommender/features/storage.py
@@ -190,3 +190,58 @@ def list_pending(run_dir: Path | str, feature_type: str, n_shards: int) -> list[
             pending_shard_ids.append(idx)
 
     return pending_shard_ids
+
+
+def read_validate_shard(
+    run_dir: Path | str, feature_type: str, shard_id: int, mmap: bool = False
+) -> tuple[np.ndarray | np.memmap, list[int]]:
+    # check shard_id is not negative
+    if shard_id < 0:
+        raise ValueError("Shard id must be >= 0.")
+    # check success marker exists
+    marker_path = success_marker_path(run_dir=run_dir, feature_type=feature_type, shard_id=shard_id)
+    if not marker_path.exists():
+        raise ValueError(f"Shard not completed, missing success marker at: {marker_path}")
+    # check artifact file paths exist
+    features_path, ids_path, meta_path = shard_paths(
+        run_dir=run_dir, feature_type=feature_type, shard_id=shard_id
+    )
+    if not features_path.exists():
+        raise ValueError(f"Features at {features_path} for this shard are missing.")
+    if not ids_path.exists():
+        raise ValueError(f"Ids at {ids_path} for this shard are missing.")
+    if not meta_path.exists():
+        raise ValueError(f"Metadata at {meta_path} for this shard is missing.")
+
+    # load features
+    if mmap:
+        try:
+            # load as memory mapped array
+            features_array = np.load(features_path, mmap_mode="r")
+        except Exception as e:
+            raise ValueError(f"Failed to load features in mmap mode: {e}") from e
+        # check type
+        if not isinstance(features_array, np.memmap):
+            raise ValueError("Features is not mmap backed.")
+    else:
+        try:
+            # load as normal array
+            features_array = np.load(features_path)
+        except Exception as e:
+            raise ValueError(f"Failed to load features in non-mmap mode: {e}") from e
+
+    # load ids
+    try:
+        ids_array = np.load(ids_path)
+        ids_list = [int(x) for x in ids_array.tolist()]
+    except Exception as e:
+        raise ValueError(f"Failed to load ids: {e}") from e
+
+    # load metadata
+    try:
+        text = meta_path.read_text(encoding="utf-8")
+        json.loads(text)
+    except Exception as e:
+        raise ValueError(f"Failed to load metadata: {e}") from e
+
+    return features_array, ids_list

--- a/src/image_recommender/util/shard_validation.py
+++ b/src/image_recommender/util/shard_validation.py
@@ -1,0 +1,46 @@
+from collections.abc import Sequence
+
+import numpy as np
+
+
+def validate_shard(
+    feature_type: str,
+    features: np.ndarray,
+    ids: Sequence[int],
+    meta: dict[str, object],
+    required_keys: set[str],
+    expected_version: int,
+) -> None:
+    # check features dimensions
+    if features.ndim != 2:
+        raise ValueError("Feature array has wrong dimensions.")
+
+    # check length matches
+    if len(ids) != features.shape[0]:
+        raise ValueError("The number of features and ids is mismatched.")
+
+    # check meta keys
+    if set(meta.keys()) != required_keys:
+        raise ValueError("The meta keys are incorrect.")
+
+    # check meta version
+    if meta["version"] != expected_version:
+        raise ValueError("Meta version mismatch.")
+
+    # check consistency with data
+    if meta["feature_dim"] != features.shape[1]:
+        raise ValueError("Metadata and data feature dimensions are mismatched.")
+
+    try:
+        meta_dt = np.dtype(meta["feature_dtype"])
+    except (TypeError, ValueError) as e:
+        raise ValueError("Metadata type is invalid.") from e
+
+    if meta_dt != features.dtype:
+        raise ValueError("Metadata and data type are mismatched.")
+
+    if meta["shard_size"] != features.shape[0]:
+        raise ValueError("Metadata and data size are mismatched.")
+
+    if meta["feature_type"] != feature_type:
+        raise ValueError("Metadata and data feature type are mismatched.")

--- a/tests/features/test_storage.py
+++ b/tests/features/test_storage.py
@@ -13,6 +13,7 @@ from image_recommender.features.storage import (
     _write_meta_json_atomic,
     list_pending,
     mark_success,
+    read_validate_shard,
     shard_dir,
     shard_paths,
     success_marker_path,
@@ -133,33 +134,13 @@ def test_write_features_npy_atomic(tmp_path: Path) -> None:
     assert data.tolist() == test_features.tolist()
 
 
-def test_write_shard_happy_path(tmp_path: Path) -> None:
+def test_write_shard_correct_artifacts(tmp_path: Path) -> None:
     # get artifact paths
     tmp_features_path, tmp_ids_path, tmp_meta_path = shard_paths(
         run_dir=tmp_path, feature_type="embedding", shard_id=50
     )
-    # create features
-    test_features = np.array([[1, 2], [3, 4]], dtype=np.float32)
-    # create ids
-    test_ids = [1, 3]
-    # create meta
-    test_meta = {
-        "feature_type": "embedding",
-        "feature_dim": 2,
-        "feature_dtype": "float32",
-        "shard_size": 2,
-        "created_at": "2026-01-12T00:00:00Z",
-        "version": VERSION,
-    }
-    # write shard
-    write_shard_atomic(
-        run_dir=tmp_path,
-        shard_id=50,
-        feature_type="embedding",
-        features=test_features,
-        ids=test_ids,
-        meta=test_meta,
-    )
+    # create shard
+    test_features, test_ids, test_meta = _create_shard_success(tmp_path)
     # check artifact paths
     assert tmp_features_path.exists()
     assert tmp_ids_path.exists()
@@ -206,3 +187,118 @@ def test_list_pending_bad_inputs(tmp_path: Path) -> None:
     missing = tmp_path / "does_not_exist"
     with pytest.raises(ValueError, match=r"missing"):
         list_pending(run_dir=missing, feature_type="hsv", n_shards=8)
+
+
+def _create_shard_success(run_dir: Path) -> None:
+    # create features
+    test_features = np.array([[1, 2], [3, 4]], dtype=np.float32)
+    # create ids
+    test_ids = [1, 3]
+    # create meta
+    test_meta = {
+        "feature_type": "embedding",
+        "feature_dim": 2,
+        "feature_dtype": "float32",
+        "shard_size": 2,
+        "created_at": "2026-01-12T00:00:00Z",
+        "version": VERSION,
+    }
+    # write shard
+    write_shard_atomic(
+        run_dir=run_dir,
+        shard_id=50,
+        feature_type="embedding",
+        features=test_features,
+        ids=test_ids,
+        meta=test_meta,
+    )
+    # write success marker
+    mark_success(run_dir=run_dir, feature_type="embedding", shard_id=50)
+
+    return test_features, test_ids, test_meta
+
+
+def test_read_incomplete_shard(tmp_path) -> None:
+    # try to load non existent shard
+    with pytest.raises(ValueError, match=r"missing success marker"):
+        read_validate_shard(run_dir=tmp_path, feature_type="hsv", shard_id=7)
+
+
+data_missing_artifacts = [
+    ("features", r"Features at .*features\.npy"),
+    ("ids", r"Ids at .*ids\.npy"),
+    ("meta", r"Metadata at .*meta\.json"),
+]
+
+
+@pytest.mark.parametrize(
+    "artifact_key, error_message", data_missing_artifacts, ids=["features", "ids", "meta"]
+)
+def test_read_shards_missing_artifacts(tmp_path, artifact_key, error_message):
+    # create shard
+    _create_shard_success(tmp_path)
+    # get artifact paths
+    features_path, ids_path, meta_path = shard_paths(
+        run_dir=tmp_path, feature_type="embedding", shard_id=50
+    )
+    # assign correct artifact path
+    if artifact_key == "features":
+        artifact_path = features_path
+    elif artifact_key == "ids":
+        artifact_path = ids_path
+    else:
+        artifact_path = meta_path
+    # delete artifact
+    artifact_path.unlink()
+    # attempt to load shard and check error message
+    with pytest.raises(ValueError, match=error_message):
+        read_validate_shard(run_dir=tmp_path, feature_type="embedding", shard_id=50)
+
+
+data_corrupt_artifacts = [("features", "load features in non-mmap"), ("ids", "load ids")]
+
+
+@pytest.mark.parametrize(
+    "artifact_key, error_message", data_corrupt_artifacts, ids=["features", "ids"]
+)
+def test_read_shards_corrupt_features_ids(tmp_path, artifact_key, error_message):
+    # create shard
+    _create_shard_success(run_dir=tmp_path)
+    # get artifact paths
+    features_path, ids_path, _ = shard_paths(
+        run_dir=tmp_path, feature_type="embedding", shard_id=50
+    )
+    # assign correct artifact path
+    if artifact_key == "features":
+        artifact_path = features_path
+    else:
+        artifact_path = ids_path
+    # corrupt artifact
+    data = artifact_path.read_bytes()
+    artifact_path.write_bytes(data[:10])
+    # attempt to load shard and check error message
+    with pytest.raises(ValueError, match=error_message):
+        read_validate_shard(run_dir=tmp_path, feature_type="embedding", shard_id=50)
+
+
+def test_read_shards_corrupt_meta(tmp_path):
+    # create shard
+    _create_shard_success(run_dir=tmp_path)
+    # get meta path
+    _, _, meta_path = shard_paths(run_dir=tmp_path, feature_type="embedding", shard_id=50)
+    # corrupt meta
+    meta_path.write_text("{not json", encoding="utf-8")
+    # attempt to load shard and check error message
+    with pytest.raises(ValueError, match="load metadata"):
+        read_validate_shard(run_dir=tmp_path, feature_type="embedding", shard_id=50)
+
+
+def test_read_shard_mmap(tmp_path):
+    # create shard
+    _create_shard_success(run_dir=tmp_path)
+    # load shard in mmap mode
+    features_array, _ = read_validate_shard(
+        run_dir=tmp_path, feature_type="embedding", shard_id=50, mmap=True
+    )
+    # double check type
+    assert isinstance(features_array, np.memmap)

--- a/tests/features/test_storage.py
+++ b/tests/features/test_storage.py
@@ -7,7 +7,6 @@ import pytest
 from image_recommender.features.storage import (
     REQUIRED_META_KEYS,
     VERSION,
-    _validate_shard_inputs,
     _write_features_npy_atomic,
     _write_ids_npy_atomic,
     _write_meta_json_atomic,
@@ -17,8 +16,9 @@ from image_recommender.features.storage import (
     shard_dir,
     shard_paths,
     success_marker_path,
-    write_shard_atomic,
+    write_validate_shard_atomic,
 )
+from image_recommender.util.shard_validation import validate_shard
 
 
 def test_shard_paths() -> None:
@@ -69,8 +69,13 @@ def test_validate_shard_inputs_raises_on_id_count_mismatch() -> None:
     }
     # check mismatch is caught
     with pytest.raises(ValueError) as exc_info:
-        _validate_shard_inputs(
-            feature_type="hsv", features=test_array, ids=mismatched_ids, meta=metadata_placeholder
+        validate_shard(
+            feature_type="hsv",
+            features=test_array,
+            ids=mismatched_ids,
+            meta=metadata_placeholder,
+            required_keys=REQUIRED_META_KEYS,
+            expected_version=VERSION,
         )
     assert str(exc_info.value) == "The number of features and ids is mismatched."
 
@@ -204,7 +209,7 @@ def _create_shard_success(run_dir: Path) -> None:
         "version": VERSION,
     }
     # write shard
-    write_shard_atomic(
+    write_validate_shard_atomic(
         run_dir=run_dir,
         shard_id=50,
         feature_type="embedding",
@@ -234,7 +239,7 @@ data_missing_artifacts = [
 @pytest.mark.parametrize(
     "artifact_key, error_message", data_missing_artifacts, ids=["features", "ids", "meta"]
 )
-def test_read_shards_missing_artifacts(tmp_path, artifact_key, error_message):
+def test_read_shards_missing_artifacts(tmp_path, artifact_key, error_message) -> None:
     # create shard
     _create_shard_success(tmp_path)
     # get artifact paths
@@ -261,7 +266,7 @@ data_corrupt_artifacts = [("features", "load features in non-mmap"), ("ids", "lo
 @pytest.mark.parametrize(
     "artifact_key, error_message", data_corrupt_artifacts, ids=["features", "ids"]
 )
-def test_read_shards_corrupt_features_ids(tmp_path, artifact_key, error_message):
+def test_read_shards_corrupt_features_ids(tmp_path, artifact_key, error_message) -> None:
     # create shard
     _create_shard_success(run_dir=tmp_path)
     # get artifact paths
@@ -281,7 +286,7 @@ def test_read_shards_corrupt_features_ids(tmp_path, artifact_key, error_message)
         read_validate_shard(run_dir=tmp_path, feature_type="embedding", shard_id=50)
 
 
-def test_read_shards_corrupt_meta(tmp_path):
+def test_read_shards_corrupt_meta(tmp_path) -> None:
     # create shard
     _create_shard_success(run_dir=tmp_path)
     # get meta path
@@ -293,7 +298,7 @@ def test_read_shards_corrupt_meta(tmp_path):
         read_validate_shard(run_dir=tmp_path, feature_type="embedding", shard_id=50)
 
 
-def test_read_shard_mmap(tmp_path):
+def test_read_shard_mmap(tmp_path) -> None:
     # create shard
     _create_shard_success(run_dir=tmp_path)
     # load shard in mmap mode
@@ -302,3 +307,35 @@ def test_read_shard_mmap(tmp_path):
     )
     # double check type
     assert isinstance(features_array, np.memmap)
+
+
+def test_meta_keys_mismatch(tmp_path) -> None:
+    # create shard
+    _create_shard_success(run_dir=tmp_path)
+    # get meta path
+    _, _, meta_path = shard_paths(run_dir=tmp_path, feature_type="embedding", shard_id=50)
+    # load metadata
+    meta_dict = json.loads(meta_path.read_text(encoding="utf-8"))
+    # remove one meta key
+    meta_dict.pop("version")
+    # persist changes
+    meta_path.write_text(json.dumps(meta_dict), encoding="utf-8")
+    # attempt to load shard and check error message
+    with pytest.raises(ValueError, match="meta keys"):
+        read_validate_shard(run_dir=tmp_path, feature_type="embedding", shard_id=50)
+
+
+def test_validation_mismatch(tmp_path) -> None:
+    # create shard
+    _create_shard_success(run_dir=tmp_path)
+    # get meta path
+    _, _, meta_path = shard_paths(run_dir=tmp_path, feature_type="embedding", shard_id=50)
+    # load metadata
+    meta_dict = json.loads(meta_path.read_text(encoding="utf-8"))
+    # change meta dimension value
+    meta_dict["feature_dim"] = 1
+    # persist changes
+    meta_path.write_text((json.dumps(meta_dict)), encoding="utf-8")
+    # attempt to load shard and check error message
+    with pytest.raises(ValueError, match="feature dimensions"):
+        read_validate_shard(run_dir=tmp_path, feature_type="embedding", shard_id=50)

--- a/tests/features/test_storage.py
+++ b/tests/features/test_storage.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Sequence
 from pathlib import Path
 
 import numpy as np
@@ -194,7 +195,7 @@ def test_list_pending_bad_inputs(tmp_path: Path) -> None:
         list_pending(run_dir=missing, feature_type="hsv", n_shards=8)
 
 
-def _create_shard_success(run_dir: Path) -> None:
+def _create_shard_success(run_dir: Path) -> tuple[np.ndarray, Sequence[int], dict[str, object]]:
     # create features
     test_features = np.array([[1, 2], [3, 4]], dtype=np.float32)
     # create ids
@@ -339,3 +340,17 @@ def test_validation_mismatch(tmp_path) -> None:
     # attempt to load shard and check error message
     with pytest.raises(ValueError, match="feature dimensions"):
         read_validate_shard(run_dir=tmp_path, feature_type="embedding", shard_id=50)
+
+
+def test_read_valid_shard(tmp_path) -> None:
+    # create shard
+    test_features, test_ids, _ = _create_shard_success(run_dir=tmp_path)
+    # load shard
+    features_array, ids_list = read_validate_shard(
+        run_dir=tmp_path, feature_type="embedding", shard_id=50
+    )
+    # compare created and loaded shard
+    assert test_features.shape == features_array.shape
+    assert test_features.dtype == features_array.dtype
+    np.testing.assert_array_equal(features_array, test_features)
+    assert test_ids == ids_list


### PR DESCRIPTION
## Linked Issue
<!-- REQUIRED: link the primary issue (e.g. "Closes #123") -->
Closes #48 

## Summary (Delta vs Issue)
<!-- What changed compared to the issue plan? If exactly as planned, say "Matches issue." -->
Matches issue.

## Scope
<!-- Short bullets of what this PR actually changes/adds. No future work. -->
- read_validate_shard
  - Enforces success marker and required artifact presence (meta.json, features.npy, ids.npy)
  - Robust loading with ValueError wrapping for meta/features/ids, plus optional mmap=True feature loading (must be memmap-backed)
    
- Extract shard artifact validation into util.validate_shard (parameterized by required_keys/expected_version) and validate meta vs loaded data on read
    
- Tests cover incomplete shards, missing artifacts, corrupt/unreadable files, mmap behavior, meta keys mismatch, one validation mismatch, and successful valid shard read assertions

## How Tested / Evidence
<!-- What proves it works? Paste commands & outcomes; attach logs/screens if useful. -->
-  pytest (all tests pass)
- Notes: Covered success gating, missing/corrupt artifact error wrapping (ValueError with informative messages), mmap=True returning a memmap-backed array, validation failures (meta keys + feature_dim mismatch), and a happy-path read returning expected features shape/dtype/values and ids list

## Risk & Rollback (optional)
<!-- Any side effects? How to revert safely if needed. -->

## Notes for Reviewers (optional)
<!-- Call out tricky parts, follow-up PRs, or decisions deviating from the issue. -->

## Checklist
- [x] Labels set (area, block, priority)
- [x] CI passes (lint-format, tests, cli-smoke)
- [x] Tests updated/added (only for what this PR changes)