### PR TITLE
Feature/issue 33/embedding distance metric

### DIFF
--- a/src/image_recommender/metrics/embedding_distance.py
+++ b/src/image_recommender/metrics/embedding_distance.py
@@ -29,3 +29,44 @@ def cosine_distance(a: np.ndarray, b: np.ndarray) -> float:
     sim = np.clip(sim, -1.0, 1.0)  # Clip the similarity value to avoid numerical issues
 
     return float(1.0 - sim)
+
+
+def cosine_distance_to_many(q: np.ndarray, X: np.ndarray) -> np.ndarray:
+    """
+    Computes cosine distance between a single query vector and
+    multiple vectors in a matrix.
+    Input: q (1D numpy array of shape (D,)), X (2D numpy array of shape (N, D)).
+    Output: 1D numpy array of shape (N,) with cosine distances.
+    Possible error: ValueError if shapes differ or if either vector is zero.
+    """
+
+    if q.ndim != 1:  # Is the query vector 1D?
+        raise ValueError("Query vector must be 1D.")
+
+    if X.ndim != 2:  # Is X a 2D matrix?
+        raise ValueError("X must be a 2D array of shape (N, D).")
+
+    if X.shape[1] != q.shape[0]:  # Does the dimensionality of q match the number of columns in X?
+        raise ValueError("Dimensionality mismatch between q and X.")
+
+    q = q.astype(np.float64, copy=False)
+    X = X.astype(np.float64, copy=False)
+
+    norm_q = np.linalg.norm(q)
+    norms_X = np.linalg.norm(X, axis=1)
+
+    if norm_q == 0.0:  # Is the query vector a zero vector?
+        raise ValueError("Cosine distance undefined for zero query vector.")
+
+    if np.any(norms_X == 0.0):  # Are there any zero vectors in X?
+        raise ValueError("Cosine distance undefined for zero vector in X.")
+
+    sims = (X @ q) / (norms_X * norm_q)
+
+    sims = np.clip(sims, -1.0, 1.0)
+
+    return 1.0 - sims  # Similarity ==> Distance
+
+# 1 - 0 = 1 ==> Orthogonal
+# 1 - 1 = 0 ==> Identical
+# 1 - (-1) = 2 ==> Opposite

--- a/src/image_recommender/metrics/embedding_distance.py
+++ b/src/image_recommender/metrics/embedding_distance.py
@@ -5,7 +5,7 @@ def cosine_distance(a: np.ndarray, b: np.ndarray) -> float:
     """
     Computes cosine distance between two 1D vectors.
     Input: a, b - 1D numpy arrays of the same shape.
-    Output: scalar float in [0, 2], where 0 means identical and 2 means opposite.
+    Output: scalar np.float64 in [0, 2], where 0 means identical and 2 means opposite.
     Possible error: ValueError if shapes differ or if either vector is zero.
     """
 
@@ -36,7 +36,7 @@ def cosine_distance_to_many(q: np.ndarray, X: np.ndarray) -> np.ndarray:
     Computes cosine distance between a single query vector and
     multiple vectors in a matrix.
     Input: q (1D numpy array of shape (D,)), X (2D numpy array of shape (N, D)).
-    Output: 1D numpy array of shape (N,) with cosine distances.
+    Output: 1D numpy array of shape (N,) as np.float64 with cosine distances.
     Possible error: ValueError if shapes differ or if either vector is zero.
     """
 

--- a/src/image_recommender/metrics/embedding_distance.py
+++ b/src/image_recommender/metrics/embedding_distance.py
@@ -67,6 +67,7 @@ def cosine_distance_to_many(q: np.ndarray, X: np.ndarray) -> np.ndarray:
 
     return 1.0 - sims  # Similarity ==> Distance
 
+
 # 1 - 0 = 1 ==> Orthogonal
 # 1 - 1 = 0 ==> Identical
 # 1 - (-1) = 2 ==> Opposite

--- a/src/image_recommender/metrics/embedding_distance.py
+++ b/src/image_recommender/metrics/embedding_distance.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+
+def cosine_distance(a: np.ndarray, b: np.ndarray) -> float:
+    """
+    Computes cosine distance between two 1D vectors.
+    Input: a, b - 1D numpy arrays of the same shape.
+    Output: scalar float in [0, 2], where 0 means identical and 2 means opposite.
+    Possible error: ValueError if shapes differ or if either vector is zero.
+    """
+
+    if a.ndim != 1 or b.ndim != 1:  # Are both inputs 1D vectors?
+        raise ValueError("Both inputs must be 1D vectors.")
+
+    if a.shape != b.shape:  # Do they have the same shape?
+        raise ValueError("Vectors must have the same shape.")
+
+    a = a.astype(np.float64, copy=False)
+    b = b.astype(np.float64, copy=False)
+
+    norm_a = np.linalg.norm(a)
+    norm_b = np.linalg.norm(b)
+
+    if norm_a == 0.0 or norm_b == 0.0:  # Is either vector a zero vector?
+        raise ValueError("Cosine distance undefined for zero vectors.")
+
+    sim = np.dot(a, b) / (norm_a * norm_b)
+
+    sim = np.clip(sim, -1.0, 1.0)  # Clip the similarity value to avoid numerical issues
+
+    return float(1.0 - sim)

--- a/tests/metrics/test_embedding_distance.py
+++ b/tests/metrics/test_embedding_distance.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pytest
+
+from image_recommender.metrics.embedding_distance import cosine_distance
+
+
+def test_self_distance_is_zero():
+    """Tests if the distance between a vector and itself is zero (within numerical tolerance)."""
+    a = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    d = cosine_distance(a, a)
+    assert abs(d) < 1e-10
+
+
+def test_symmetry():
+    """Tests if cosine_distance(a,b) = cosine_distance(b,a)."""
+    a = np.array([1.0, 0.0, 1.0], dtype=np.float32)
+    b = np.array([0.0, 1.0, 1.0], dtype=np.float32)
+
+    d1 = cosine_distance(a, b)
+    d2 = cosine_distance(b, a)
+
+    assert abs(d1 - d2) < 1e-10
+
+
+def test_shape_mismatch_raises():
+    """Tests if ValueError is raised when input vectors have different shapes."""
+    a = np.array([1.0, 2.0])
+    b = np.array([1.0, 2.0, 3.0])
+
+    with pytest.raises(ValueError):
+        cosine_distance(a, b)
+
+
+def test_zero_vector_raises():
+    """
+    Tests if ValueError is raised when either input vector is a zero vector.
+    """
+    a = np.array([0.0, 0.0, 0.0])
+    b = np.array([1.0, 2.0, 3.0])
+
+    with pytest.raises(ValueError):
+        cosine_distance(a, b)

--- a/tests/metrics/test_embedding_distance.py
+++ b/tests/metrics/test_embedding_distance.py
@@ -68,3 +68,19 @@ def test_vectorized_matches_scalar():
     for i in range(len(X)):
         scalar = cosine_distance(q, X[i])
         assert abs(dists[i] - scalar) < 1e-10
+
+
+def test_non_1d_input_raises():
+    """Tests if ValueError is raised when input is not 1D."""
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    b = np.array([1.0, 2.0])
+    with pytest.raises(ValueError):
+        cosine_distance(a, b)
+
+
+def test_zero_vector_in_X_raises():
+    """Tests if ValueError is raised when X contains a zero vector."""
+    q = np.array([1.0, 1.0])
+    X = np.array([[0.0, 0.0], [1.0, 1.0]])
+    with pytest.raises(ValueError):
+        cosine_distance_to_many(q, X)

--- a/tests/metrics/test_embedding_distance.py
+++ b/tests/metrics/test_embedding_distance.py
@@ -3,7 +3,7 @@ import pytest
 
 from image_recommender.metrics.embedding_distance import (
     cosine_distance,
-    cosine_distance_to_many
+    cosine_distance_to_many,
 )
 
 

--- a/tests/metrics/test_embedding_distance.py
+++ b/tests/metrics/test_embedding_distance.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pytest
 
-from image_recommender.metrics.embedding_distance import cosine_distance, cosine_distance_to_many
+from image_recommender.metrics.embedding_distance import (
+    cosine_distance,
+    cosine_distance_to_many
+)
 
 
 def test_self_distance_is_zero():

--- a/tests/metrics/test_embedding_distance.py
+++ b/tests/metrics/test_embedding_distance.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from image_recommender.metrics.embedding_distance import cosine_distance
+from image_recommender.metrics.embedding_distance import cosine_distance, cosine_distance_to_many
 
 
 def test_self_distance_is_zero():
@@ -40,3 +40,28 @@ def test_zero_vector_raises():
 
     with pytest.raises(ValueError):
         cosine_distance(a, b)
+
+
+def test_vectorized_shape():
+    """Tests if the output shape of cosine_distance_to_many is correct given input shapes."""
+    q = np.array([1.0, 0.0])
+    X = np.array([[1.0, 0.0], [0.0, 1.0]])
+
+    dists = cosine_distance_to_many(q, X)
+
+    assert dists.shape == (2,)
+
+
+def test_vectorized_matches_scalar():
+    """
+    Tests if the vectorized cosine_distance_to_many produces the same results
+    as individual cosine_distance calls (within numerical tolerance).
+    """
+    q = np.array([1.0, 1.0])
+    X = np.array([[1.0, 1.0], [1.0, -1.0]])
+
+    dists = cosine_distance_to_many(q, X)
+
+    for i in range(len(X)):
+        scalar = cosine_distance(q, X[i])
+        assert abs(dists[i] - scalar) < 1e-10


### PR DESCRIPTION
## Linked Issue
<!-- REQUIRED: link the primary issue (e.g. "Closes #123") -->
Closes #33

## Summary (Delta vs Issue)
Matches issue.

## Scope
- cosine_distance function for computing distance between two 1D vectors
- input shapes validation
- cosine_distance_to_many function for computing distances between a query vector and multiple vectors in a matrix
- distance semantic described:
sim = 1 --> distance = 0 ==> identical
sim = 0 --> distance = 1 ==> orthogonal
sim = -1 --> distance = 2 ==> opposite

## How Tested / Evidence
-  Tested with tests/metrics/test_embedding_distance.py
<pre> pytest -q tests/metrics/test_embedding_distance.py --> Result: 6 passed in 0.86 s </pre>

## Risk & Rollback (optional)
<!-- Any side effects? How to revert safely if needed. -->

## Notes for Reviewers (optional)
<!-- Call out tricky parts, follow-up PRs, or decisions deviating from the issue. -->

## Checklist
- [x] Labels set (area, block, priority)
- [x] CI passes (lint-format, tests, cli-smoke)
- [x] Tests updated/added (only for what this PR changes)