### PR TITLE
Feature/issue 55/linear search backend

### DIFF
--- a/src/image_recommender/search/linear.py
+++ b/src/image_recommender/search/linear.py
@@ -24,7 +24,7 @@ class LinearSearchBackend:
         distance_fn: Callable[[np.ndarray, np.ndarray], np.ndarray],
         k: int,
         mmap: bool = False,
-    ):
+    ) -> None:
         if not isinstance(k, int) or k <= 0:
             raise ValueError(f"Invalid k={k}. Must be a positive integer.")
 
@@ -37,9 +37,7 @@ class LinearSearchBackend:
         self.shard_ids = self._discover_shards()
 
     def _discover_shards(self) -> list[int]:
-        """
-        Discovers all shards in the run directory.
-        """
+        """Discovers all shards in the run directory."""
         feature_dir = self.run_dir / self.feature_type
         if not feature_dir.exists():
             raise ValueError(f"Shard directory {feature_dir} does not exist.")
@@ -47,7 +45,7 @@ class LinearSearchBackend:
         shard_ids: list[int] = []
         for path in feature_dir.iterdir():
             if path.is_dir():
-                match = re.fullmatch(r"shard_(\d{4})", path.name)
+                match = re.fullmatch(r"shard_(\d{4})", path.name)  # e.g., shard_0001
                 if match:
                     shard_ids.append(int(match.group(1)))
 
@@ -57,44 +55,13 @@ class LinearSearchBackend:
         return sorted(shard_ids)
 
     def _load_shard(self, shard_id: int) -> tuple[np.ndarray, list[int]]:
-        """
-        Loads a shard from the run directory.
-        """
+        """Loads a shard from the run directory."""
         return read_validate_shard(
             run_dir=self.run_dir,
             feature_type=self.feature_type,
             shard_id=shard_id,
             mmap=self.mmap,
         )
-
-    def _compute_shard_distances(
-        self, query: np.ndarray, candidates: np.ndarray
-    ) -> tuple[np.ndarray, int]:
-        """
-        Computes distances for a shard and handles anomalies (NaN/Inf).
-        Input: query, candidates
-        Output: distances, anomalies
-        """
-        if query.ndim != 1 or query.size == 0:
-            raise ValueError("Query must be a non-empty 1D array.")
-        if candidates.ndim != 2:
-            raise ValueError("Candidates must be a 2D array.")
-        if query.shape[0] != candidates.shape[1]:
-            raise ValueError("Dimensionality mismatch between query and candidates.")
-
-        dists = self.distance_fn(query, candidates)
-        if not isinstance(dists, np.ndarray) or dists.ndim != 1:
-            raise ValueError("Distance function must return a 1D numpy array.")
-        if dists.shape[0] != candidates.shape[0]:
-            raise ValueError("Distance output size mismatch.")
-
-        invalid_mask = ~np.isfinite(dists)
-        anomalies = int(np.sum(invalid_mask))
-        if anomalies > 0:
-            dists = dists.copy()
-            dists[invalid_mask] = np.inf
-
-        return dists.astype(np.float32, copy=False), anomalies
 
     def search(self, query: np.ndarray) -> tuple[list[int], np.ndarray]:
         """
@@ -111,38 +78,65 @@ class LinearSearchBackend:
         if np.linalg.norm(query) == 0:
             raise ValueError("Query vector must not be zero.")
 
-        heap: list[tuple[np.float32, int]] = []
-        total_candidates = 0
+        heap: list[tuple[float, int]] = []
+        total_valid_candidates = 0
+        expected_dim: int | None = None
 
         for shard_id in self.shard_ids:
-            candidates, candidate_ids = self._load_shard(shard_id)
-            total_candidates += candidates.shape[0]
+            features, ids = self._load_shard(shard_id)
 
-            dists, anomalies = self._compute_shard_distances(query, candidates)
+            if expected_dim is None:
+                expected_dim = features.shape[1]
 
-            if anomalies > 0:
+            if query.shape[0] != expected_dim:
+                raise ValueError("Dimensionality mismatch between query and features.")
+
+            distances = self.distance_fn(query, features)
+
+            if not isinstance(distances, np.ndarray) or distances.ndim != 1:
+                raise ValueError("Distance function must return a 1D numpy array.")
+
+            if distances.shape[0] != features.shape[0]:
+                raise ValueError("Distance output size mismatch.")
+
+            invalid_mask = ~np.isfinite(distances)
+            anomaly_count = int(np.sum(invalid_mask))
+
+            if anomaly_count > 0:
                 logger.warning(
-                    "%d invalid candidate distances (+inf) in shard %04d",
-                    anomalies,
+                    "%d invalid candidate distances (+inf) in shard %04d",  # e.g. 0001 instead of 1
+                    anomaly_count,
                     shard_id,
                 )
+                distances = distances.copy()
+                distances[invalid_mask] = np.inf
 
-            for dist, idx in zip(dists, candidate_ids, strict=True):
+            valid_mask = np.isfinite(distances)
+            total_valid_candidates += int(np.sum(valid_mask))
+
+            for dist, img_id in zip(distances, ids, strict=True):
                 if not np.isfinite(dist):
                     continue
+
                 if len(heap) < self.k:
-                    heapq.heappush(heap, (-dist, idx))
+                    heapq.heappush(heap, (-float(dist), img_id))
                 else:
                     if dist < -heap[0][0]:  # If the new candidate is closer than the farthest...
                         heapq.heapreplace(
-                            heap, (-dist, idx)
+                            heap, (-float(dist), img_id)
                         )  # ...replace the farthest with the new closer one.
 
         if len(heap) < self.k:
             raise ValueError(
-                f"Not enough valid candidates ({total_candidates}) to retrieve k={self.k} neighbors."
+                f"Not enough valid candidates ({total_valid_candidates}) "
+                f"to retrieve k={self.k} neighbors."
             )
 
-        sorted_topk = sorted([(-dist, idx) for dist, idx in heap], key=lambda x: x[0])
-        distances, ids = zip(*sorted_topk, strict=True)
-        return list(ids), np.asarray(distances, dtype=np.float32)
+        sorted_topk = sorted(  # sort ascending by distance
+            [(-dist, img_id) for dist, img_id in heap],
+            key=lambda x: x[0],
+        )
+
+        distances_sorted, ids_sorted = zip(*sorted_topk, strict=True)
+
+        return list(ids_sorted), np.asarray(distances_sorted, dtype=np.float32)

--- a/src/image_recommender/search/linear.py
+++ b/src/image_recommender/search/linear.py
@@ -1,0 +1,67 @@
+import logging
+import re
+from collections.abc import Callable
+from pathlib import Path
+
+import numpy as np
+
+from image_recommender.features.storage import read_validate_shard
+
+logger = logging.getLogger("project.search")
+
+
+class LinearSearchBackend:
+    """
+    Exact linear search backend that retrieves the k nearest neighbors
+    across all feature shards using a provided vectorized distance function.
+    """
+
+    def __init__(
+        self,
+        run_dir: Path,
+        feature_type: str,
+        distance_fn: Callable[[np.ndarray, np.ndarray], np.ndarray],
+        k: int,
+        mmap: bool = False,
+    ):
+        if not isinstance(k, int) or k <= 0:
+            raise ValueError(f"Invalid k={k}. Must be a positive integer.")
+
+        self.run_dir = Path(run_dir)
+        self.feature_type = feature_type
+        self.distance_fn = distance_fn
+        self.k = k
+        self.mmap = mmap
+
+        self.shard_ids = self._discover_shards()
+
+    def _discover_shards(self) -> list[int]:
+        """
+        Discovers all shards in the run directory.
+        """
+        feature_dir = self.run_dir / self.feature_type
+        if not feature_dir.exists():
+            raise ValueError(f"Shard directory {feature_dir} does not exist.")
+
+        shard_ids: list[int] = []
+        for path in feature_dir.iterdir():
+            if path.is_dir():
+                match = re.fullmatch(r"shard_(\d{4})", path.name)
+                if match:
+                    shard_ids.append(int(match.group(1)))
+
+        if not shard_ids:
+            raise ValueError(f"No shards found in {feature_dir}.")
+
+        return sorted(shard_ids)
+
+    def _load_shard(self, shard_id: int) -> tuple[np.ndarray, list[int]]:
+        """
+        Loads a shard from the run directory.
+        """
+        return read_validate_shard(
+            run_dir=self.run_dir,
+            feature_type=self.feature_type,
+            shard_id=shard_id,
+            mmap=self.mmap,
+        )

--- a/src/image_recommender/search/linear.py
+++ b/src/image_recommender/search/linear.py
@@ -1,5 +1,4 @@
 import heapq
-import logging
 import re
 from collections.abc import Callable
 from pathlib import Path
@@ -7,8 +6,9 @@ from pathlib import Path
 import numpy as np
 
 from image_recommender.features.storage import read_validate_shard
+from image_recommender.util.logs import get_logger
 
-logger = logging.getLogger("project.search")
+logger = get_logger(__name__)
 
 
 class LinearSearchBackend:

--- a/src/image_recommender/search/linear.py
+++ b/src/image_recommender/search/linear.py
@@ -1,3 +1,4 @@
+import heapq
 import logging
 import re
 from collections.abc import Callable
@@ -65,3 +66,83 @@ class LinearSearchBackend:
             shard_id=shard_id,
             mmap=self.mmap,
         )
+
+    def _compute_shard_distances(
+        self, query: np.ndarray, candidates: np.ndarray
+    ) -> tuple[np.ndarray, int]:
+        """
+        Computes distances for a shard and handles anomalies (NaN/Inf).
+        Input: query, candidates
+        Output: distances, anomalies
+        """
+        if query.ndim != 1 or query.size == 0:
+            raise ValueError("Query must be a non-empty 1D array.")
+        if candidates.ndim != 2:
+            raise ValueError("Candidates must be a 2D array.")
+        if query.shape[0] != candidates.shape[1]:
+            raise ValueError("Dimensionality mismatch between query and candidates.")
+
+        dists = self.distance_fn(query, candidates)
+        if not isinstance(dists, np.ndarray) or dists.ndim != 1:
+            raise ValueError("Distance function must return a 1D numpy array.")
+        if dists.shape[0] != candidates.shape[0]:
+            raise ValueError("Distance output size mismatch.")
+
+        invalid_mask = ~np.isfinite(dists)
+        anomalies = int(np.sum(invalid_mask))
+        if anomalies > 0:
+            dists = dists.copy()
+            dists[invalid_mask] = np.inf
+
+        return dists.astype(np.float32, copy=False), anomalies
+
+    def search(self, query: np.ndarray) -> tuple[list[int], np.ndarray]:
+        """
+        Performs a linear search over all shards and returns top-k nearest neighbors.
+        Input: query
+        Output: ids, distances (sorted list)
+        """
+        if not isinstance(query, np.ndarray):
+            raise ValueError("Query must be a numpy array.")
+        if query.ndim != 1 or query.size == 0:
+            raise ValueError("Query must be a non-empty 1D array.")
+        if not np.isfinite(query).all():
+            raise ValueError("Query contains invalid (nan or inf) values.")
+        if np.linalg.norm(query) == 0:
+            raise ValueError("Query vector must not be zero.")
+
+        heap: list[tuple[np.float32, int]] = []
+        total_candidates = 0
+
+        for shard_id in self.shard_ids:
+            candidates, candidate_ids = self._load_shard(shard_id)
+            total_candidates += candidates.shape[0]
+
+            dists, anomalies = self._compute_shard_distances(query, candidates)
+
+            if anomalies > 0:
+                logger.warning(
+                    "%d invalid candidate distances (+inf) in shard %04d",
+                    anomalies,
+                    shard_id,
+                )
+
+            for dist, idx in zip(dists, candidate_ids, strict=True):
+                if not np.isfinite(dist):
+                    continue
+                if len(heap) < self.k:
+                    heapq.heappush(heap, (-dist, idx))
+                else:
+                    if dist < -heap[0][0]:  # If the new candidate is closer than the farthest...
+                        heapq.heapreplace(
+                            heap, (-dist, idx)
+                        )  # ...replace the farthest with the new closer one.
+
+        if len(heap) < self.k:
+            raise ValueError(
+                f"Not enough valid candidates ({total_candidates}) to retrieve k={self.k} neighbors."
+            )
+
+        sorted_topk = sorted([(-dist, idx) for dist, idx in heap], key=lambda x: x[0])
+        distances, ids = zip(*sorted_topk, strict=True)
+        return list(ids), np.asarray(distances, dtype=np.float32)

--- a/tests/search/test_linear.py
+++ b/tests/search/test_linear.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from image_recommender.search.linear import LinearSearchBackend
+
+
+def euclidean_distance(query, candidates):
+    diff = candidates - query
+    return np.sqrt(np.sum(diff**2, axis=1))
+
+
+# temporary dummy shards:
+
+
+@pytest.fixture
+def fake_shards(tmp_path: Path):
+    run_dir = tmp_path
+    feature_type = "embedding"
+    feature_dir = run_dir / feature_type
+    feature_dir.mkdir()
+
+    for shard_id in range(2):
+        shard_path = feature_dir / f"shard_{shard_id:04d}"
+        shard_path.mkdir()
+
+        features = np.eye(3, dtype=np.float32) * (shard_id + 1)
+        ids = np.arange(shard_id * 3, shard_id * 3 + 3, dtype=np.int64)
+
+        np.save(shard_path / "features.npy", features)
+        np.save(shard_path / "ids.npy", ids)
+
+        meta = {
+            "feature_type": feature_type,
+            "feature_dim": 3,
+            "feature_dtype": "float32",
+            "shard_size": 3,
+            "created_at": "now",
+            "version": 1,
+        }
+        (shard_path / "meta.json").write_text(json.dumps(meta))
+        (shard_path / "_SUCCESS").touch()
+
+    return run_dir, feature_type
+
+
+def test_shard_discovery(fake_shards):
+    """Tests that shards are discovered correctly."""
+    run_dir, feature_type = fake_shards
+    backend = LinearSearchBackend(
+        run_dir=run_dir,
+        feature_type=feature_type,
+        distance_fn=euclidean_distance,
+        k=1,
+    )
+
+    assert len(backend.shard_ids) == 2  # Are there 2 shards?
+    # check order of the shards:
+    assert backend.shard_ids[0] == 0
+    assert backend.shard_ids[1] == 1

--- a/tests/search/test_linear.py
+++ b/tests/search/test_linear.py
@@ -7,7 +7,7 @@ import pytest
 from image_recommender.search.linear import LinearSearchBackend
 
 
-def euclidean_distance(query, candidates):
+def euclidean_distance(query: np.ndarray, candidates: np.ndarray) -> np.ndarray:
     diff = candidates - query
     return np.sqrt(np.sum(diff**2, axis=1))
 
@@ -16,7 +16,7 @@ def euclidean_distance(query, candidates):
 
 
 @pytest.fixture
-def fake_shards(tmp_path: Path):
+def fake_shards(tmp_path: Path) -> tuple[Path, str]:
     run_dir = tmp_path
     feature_type = "embedding"
     feature_dir = run_dir / feature_type
@@ -60,3 +60,96 @@ def test_shard_discovery(fake_shards):
     # check order of the shards:
     assert backend.shard_ids[0] == 0
     assert backend.shard_ids[1] == 1
+
+
+def test_topk_sorted_and_exact_length(fake_shards):
+    """Tests that the top-k results are sorted and have the correct length."""
+    run_dir, feature_type = fake_shards
+    backend = LinearSearchBackend(
+        run_dir=run_dir,
+        feature_type=feature_type,
+        distance_fn=euclidean_distance,
+        k=4,
+    )
+    query = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+    ids, dists = backend.search(query)
+
+    assert len(ids) == 4
+    assert dists.dtype == np.float32
+    assert np.all(np.diff(dists) >= 0)
+
+
+def test_self_match_distance_zero(fake_shards):
+    """Tests that the distance to self is zero."""
+    run_dir, feature_type = fake_shards
+    backend = LinearSearchBackend(
+        run_dir=run_dir,
+        feature_type=feature_type,
+        distance_fn=euclidean_distance,
+        k=1,
+    )
+    query = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+    _, dists = backend.search(query)
+    assert pytest.approx(dists[0], abs=1e-10) == 0.0
+
+
+def test_zero_query_raises(fake_shards):
+    """Tests that a zero query raises an error."""
+    run_dir, feature_type = fake_shards
+    backend = LinearSearchBackend(
+        run_dir=run_dir,
+        feature_type=feature_type,
+        distance_fn=euclidean_distance,
+        k=2,
+    )
+    with pytest.raises(ValueError):
+        backend.search(np.zeros(3, dtype=np.float32))
+
+
+def test_dimensionality_mismatch(fake_shards):
+    """Tests that a dimensionality mismatch raises an error."""
+    run_dir, feature_type = fake_shards
+    backend = LinearSearchBackend(
+        run_dir=run_dir,
+        feature_type=feature_type,
+        distance_fn=euclidean_distance,
+        k=2,
+    )
+    with pytest.raises(ValueError):
+        backend.search(np.array([1.0, 2.0]))
+
+
+def test_anomaly_logging(fake_shards, caplog):
+    """Tests that anomaly logging works."""
+    run_dir, feature_type = fake_shards
+
+    def distance_with_inf(query: np.ndarray, candidates: np.ndarray) -> np.ndarray:
+        d = euclidean_distance(query, candidates)
+        d[0] = np.inf
+        d[1] = np.nan
+        return d
+
+    backend = LinearSearchBackend(
+        run_dir=run_dir,
+        feature_type=feature_type,
+        distance_fn=distance_with_inf,
+        k=2,
+    )
+    query = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+    with caplog.at_level("WARNING"):
+        backend.search(query)
+    assert any("invalid candidate distances" in r.message for r in caplog.records)
+
+
+def test_mmap_support(fake_shards):
+    run_dir, feature_type = fake_shards
+    backend = LinearSearchBackend(
+        run_dir=run_dir,
+        feature_type=feature_type,
+        distance_fn=euclidean_distance,
+        k=2,
+        mmap=True,
+    )
+    query = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+    ids, _ = backend.search(query)
+    assert len(ids) == 2

--- a/tests/search/test_linear.py
+++ b/tests/search/test_linear.py
@@ -1,155 +1,138 @@
-import json
 from pathlib import Path
 
 import numpy as np
 import pytest
 
+from image_recommender.features.storage import read_validate_shard
 from image_recommender.search.linear import LinearSearchBackend
 
 
 def euclidean_distance(query: np.ndarray, candidates: np.ndarray) -> np.ndarray:
+    """Returns the euclidean distance between a query and a set of candidates."""
     diff = candidates - query
     return np.sqrt(np.sum(diff**2, axis=1))
 
 
-# temporary dummy shards:
+@pytest.fixture(scope="module")  # fixture for the LinearSearchBackend
+def hsv_pilot_backend() -> LinearSearchBackend:
+    """Returns a LinearSearchBackend instance for the pilot dataset."""
+    run_dir = Path("data/features/pilot")
+    feature_type = "hsv"
 
-
-@pytest.fixture
-def fake_shards(tmp_path: Path) -> tuple[Path, str]:
-    run_dir = tmp_path
-    feature_type = "embedding"
-    feature_dir = run_dir / feature_type
-    feature_dir.mkdir()
-
-    for shard_id in range(2):
-        shard_path = feature_dir / f"shard_{shard_id:04d}"
-        shard_path.mkdir()
-
-        features = np.eye(3, dtype=np.float32) * (shard_id + 1)
-        ids = np.arange(shard_id * 3, shard_id * 3 + 3, dtype=np.int64)
-
-        np.save(shard_path / "features.npy", features)
-        np.save(shard_path / "ids.npy", ids)
-
-        meta = {
-            "feature_type": feature_type,
-            "feature_dim": 3,
-            "feature_dtype": "float32",
-            "shard_size": 3,
-            "created_at": "now",
-            "version": 1,
-        }
-        (shard_path / "meta.json").write_text(json.dumps(meta))
-        (shard_path / "_SUCCESS").touch()
-
-    return run_dir, feature_type
-
-
-def test_shard_discovery(fake_shards):
-    """Tests that shards are discovered correctly."""
-    run_dir, feature_type = fake_shards
-    backend = LinearSearchBackend(
+    return LinearSearchBackend(
         run_dir=run_dir,
         feature_type=feature_type,
         distance_fn=euclidean_distance,
-        k=1,
+        k=5,
     )
 
-    assert len(backend.shard_ids) == 2  # Are there 2 shards?
-    # check order of the shards:
-    assert backend.shard_ids[0] == 0
-    assert backend.shard_ids[1] == 1
+
+@pytest.fixture(scope="module")
+def sample_query():
+    """Returns a feature vector from shard 0 and its corresponding image id."""
+    run_dir = Path("data/features/pilot")
+    features, ids = read_validate_shard(
+        run_dir=run_dir,
+        feature_type="hsv",
+        shard_id=0,
+    )
+    return features[0], ids[0]
 
 
-def test_topk_sorted_and_exact_length(fake_shards):
+@pytest.mark.integration  # integration test for LinearSearch
+def test_self_match_top1(hsv_pilot_backend, sample_query):
+    """Tests that the top-1 result is the same as the query."""
+    query, expected_id = sample_query
+
+    ids, dists = hsv_pilot_backend.search(query)
+
+    assert ids[0] == expected_id
+    assert dists[0] < 1e-10
+
+
+@pytest.mark.integration
+def test_result_length_and_sorted(hsv_pilot_backend, sample_query):
     """Tests that the top-k results are sorted and have the correct length."""
-    run_dir, feature_type = fake_shards
-    backend = LinearSearchBackend(
-        run_dir=run_dir,
-        feature_type=feature_type,
-        distance_fn=euclidean_distance,
-        k=4,
-    )
-    query = np.array([1.0, 0.0, 0.0], dtype=np.float32)
-    ids, dists = backend.search(query)
+    query, _ = sample_query
 
-    assert len(ids) == 4
+    ids, dists = hsv_pilot_backend.search(query)
+
+    assert len(ids) == hsv_pilot_backend.k
     assert dists.dtype == np.float32
     assert np.all(np.diff(dists) >= 0)
 
 
-def test_self_match_distance_zero(fake_shards):
-    """Tests that the distance to self is zero."""
-    run_dir, feature_type = fake_shards
-    backend = LinearSearchBackend(
-        run_dir=run_dir,
-        feature_type=feature_type,
-        distance_fn=euclidean_distance,
-        k=1,
-    )
-    query = np.array([1.0, 0.0, 0.0], dtype=np.float32)
-    _, dists = backend.search(query)
-    assert pytest.approx(dists[0], abs=1e-10) == 0.0
-
-
-def test_zero_query_raises(fake_shards):
-    """Tests that a zero query raises an error."""
-    run_dir, feature_type = fake_shards
-    backend = LinearSearchBackend(
-        run_dir=run_dir,
-        feature_type=feature_type,
-        distance_fn=euclidean_distance,
-        k=2,
-    )
-    with pytest.raises(ValueError):
-        backend.search(np.zeros(3, dtype=np.float32))
-
-
-def test_dimensionality_mismatch(fake_shards):
+@pytest.mark.integration
+def test_dimensionality_mismatch(hsv_pilot_backend):
     """Tests that a dimensionality mismatch raises an error."""
-    run_dir, feature_type = fake_shards
-    backend = LinearSearchBackend(
-        run_dir=run_dir,
-        feature_type=feature_type,
-        distance_fn=euclidean_distance,
-        k=2,
-    )
     with pytest.raises(ValueError):
-        backend.search(np.array([1.0, 2.0]))
+        hsv_pilot_backend.search(np.array([1.0, 2.0]))
 
 
-def test_anomaly_logging(fake_shards, caplog):
-    """Tests that anomaly logging works."""
-    run_dir, feature_type = fake_shards
+@pytest.mark.integration
+def test_zero_query_raises(hsv_pilot_backend):
+    """Tests that a zero query raises an error."""
+    dim = read_validate_shard(
+        run_dir=Path("data/features/pilot"),
+        feature_type="hsv",
+        shard_id=0,
+    )[
+        0
+    ].shape[1]
 
-    def distance_with_inf(query: np.ndarray, candidates: np.ndarray) -> np.ndarray:
-        d = euclidean_distance(query, candidates)
-        d[0] = np.inf
-        d[1] = np.nan
+    with pytest.raises(ValueError):
+        hsv_pilot_backend.search(np.zeros(dim, dtype=np.float32))
+
+
+@pytest.mark.integration
+def test_invalid_k_raises():
+    """Tests that an invalid k raises an error."""
+    with pytest.raises(ValueError):
+        LinearSearchBackend(
+            run_dir=Path("data/features/pilot"),
+            feature_type="hsv",
+            distance_fn=euclidean_distance,
+            k=0,
+        )
+
+
+@pytest.mark.integration
+def test_anomaly_handling(sample_query):
+    """Tests that +inf and NaN distances are ignored and do not break search."""
+    query, _ = sample_query
+
+    def broken_distance(q: np.ndarray, c: np.ndarray) -> np.ndarray:
+        d = euclidean_distance(q, c)
+        d[0] = np.nan  # first candidate is invalid (NaN)
+        d[1] = np.inf  # second candidate is invalid (+inf)
         return d
 
     backend = LinearSearchBackend(
-        run_dir=run_dir,
-        feature_type=feature_type,
-        distance_fn=distance_with_inf,
-        k=2,
+        run_dir=Path("data/features/pilot"),
+        feature_type="hsv",
+        distance_fn=broken_distance,
+        k=3,
     )
-    query = np.array([1.0, 0.0, 0.0], dtype=np.float32)
-    with caplog.at_level("WARNING"):
-        backend.search(query)
-    assert any("invalid candidate distances" in r.message for r in caplog.records)
+
+    ids, dists = backend.search(query)
+
+    assert len(ids) == 3
+    assert np.all(np.isfinite(dists))  # Are all distances finite after anomaly handling?
 
 
-def test_mmap_support(fake_shards):
-    run_dir, feature_type = fake_shards
+@pytest.mark.integration
+def test_mmap_support(sample_query):
+    """Tests that mmap support works correctly."""
+    query, _ = sample_query
+
     backend = LinearSearchBackend(
-        run_dir=run_dir,
-        feature_type=feature_type,
+        run_dir=Path("data/features/pilot"),
+        feature_type="hsv",
         distance_fn=euclidean_distance,
-        k=2,
+        k=3,
         mmap=True,
     )
-    query = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+
     ids, _ = backend.search(query)
-    assert len(ids) == 2
+
+    assert len(ids) == 3


### PR DESCRIPTION
## Linked Issue
<!-- REQUIRED: link the primary issue (e.g. "Closes #123") -->
Closes #55

## Summary (Delta vs Issue)
Matches issue.

## Scope
<!-- Short bullets of what this PR actually changes/adds. No future work. -->
- implement exact linear search backend for top-k neighbors across all shards
- validate queries (invalid k, dimensionality mismatch, zero vectors)
- handle candidate anomalies (+inf / NaN) safely and log per shard
- maintains global top-k with max-heap, results sorted ascending
- support both normal and mmap shard loading
- includes integration tests for correctness and edge cases

## How Tested / Evidence
<!-- What proves it works? Paste commands & outcomes; attach logs/screens if useful. -->
-  Tested with tests/search/test_linear.py
<pre>  pytest -q tests/search/test_linear.py --> Result: 7 passed in 0.66 s </pre>

## Risk & Rollback (optional)
<!-- Any side effects? How to revert safely if needed. -->

## Notes for Reviewers (optional)
<!-- Call out tricky parts, follow-up PRs, or decisions deviating from the issue. -->

## Checklist
- [x] Labels set (area, block, priority)
- [x] CI passes (lint-format, tests, cli-smoke)
- [x] Tests updated/added (only for what this PR changes)