### PR TITLE
Feature/issue 58/perceptual hash distance metric hamming

### DIFF
--- a/src/image_recommender/metrics/hamming.py
+++ b/src/image_recommender/metrics/hamming.py
@@ -2,6 +2,17 @@ import numpy as np
 
 
 def hamming_distance(query: np.ndarray, candidate: np.ndarray) -> int:
+    """
+    Computes hamming distance between two vectors.
+    Hamming distance is the number of positions at which the corresponding elements of the vectors differ.
+
+    Input:
+        query: 1D binary vector of shape (D,)
+        candidate: 1D binary vector of shape (D,)
+
+    Output:
+        Integer representing the number of differing positions
+    """
     # ensure input shapes match
     if query.shape != candidate.shape:
         raise ValueError(
@@ -18,6 +29,17 @@ def hamming_distance(query: np.ndarray, candidate: np.ndarray) -> int:
 
 
 def hamming_distance_to_many(query: np.ndarray, candidates: np.ndarray) -> np.ndarray:
+    """
+    Computes hamming distances between one query vector and multiple candidates.
+    Compares the query vector to each row in the candidate matrix and returns the number of differing positions for each candidate.
+
+    Input:
+        query: 1D binary vector of shape (D,)
+        candidates: 2D matrix of binary vectors of shape (N, D)
+
+    Output:
+        1D array of shape (N,) containing the Hamming distance to each candidate
+    """
     # ensure input dimensions are correct
     if query.ndim != 1 or candidates.ndim != 2:
         raise ValueError(

--- a/src/image_recommender/metrics/hamming.py
+++ b/src/image_recommender/metrics/hamming.py
@@ -15,3 +15,25 @@ def hamming_distance(query: np.ndarray, candidate: np.ndarray) -> int:
     distance = int(np.count_nonzero(bit_difference))
 
     return distance
+
+
+def hamming_distance_to_many(query: np.ndarray, candidates: np.ndarray) -> np.ndarray:
+    # ensure input dimensions are correct
+    if query.ndim != 1 or candidates.ndim != 2:
+        raise ValueError(
+            f"Dimension of query: {query.ndim} or candidate: {candidates.ndim} are wrong. Expected query: 1, candidates: 2 "
+        )
+
+    # ensure input lengths match
+    if query.shape[0] != candidates.shape[1]:
+        raise ValueError(
+            f"Length of query: {query.shape} and candidate vectors: {candidates.shape} doesn't match"
+        )
+
+    # compare query vector to each candidate row
+    bit_difference = query != candidates
+
+    # compute hamming distances
+    distances = np.count_nonzero(bit_difference, axis=1)
+
+    return distances

--- a/src/image_recommender/metrics/hamming.py
+++ b/src/image_recommender/metrics/hamming.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+
+def hamming_distance(query: np.ndarray, candidate: np.ndarray) -> int:
+    # ensure input shapes match
+    if query.shape != candidate.shape:
+        raise ValueError(
+            f"Shapes of query: {query.shape} and candidate: {candidate.shape} don't match"
+        )
+
+    # compare vectors element wise
+    bit_difference = query != candidate
+
+    # compute hamming distance
+    distance = int(np.count_nonzero(bit_difference))
+
+    return distance

--- a/tests/metrics/test_hamming.py
+++ b/tests/metrics/test_hamming.py
@@ -38,3 +38,16 @@ def test_vectorized_matches_scalar():
     v_result = hamming_distance_to_many(query=vector_1, candidates=vectors)
 
     assert np.array_equal(s_result, v_result)
+
+
+def test_vectorized_output_shape():
+    vector_1 = np.array([1, 0, 1, 0, 1, 0, 1, 0], dtype=np.uint8)
+    vector_2 = np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.uint8)
+    vector_3 = np.array([0, 0, 0, 0, 0, 0, 0, 0], dtype=np.uint8)
+    vector_4 = np.array([0, 1, 0, 1, 0, 1, 0, 1], dtype=np.uint8)
+
+    vectors = np.asarray([vector_2, vector_3, vector_4])
+
+    result = hamming_distance_to_many(query=vector_1, candidates=vectors)
+
+    assert result.shape == (3,)

--- a/tests/metrics/test_hamming.py
+++ b/tests/metrics/test_hamming.py
@@ -8,3 +8,13 @@ def test_self_distance():
     result = hamming_distance(query=vector, candidate=vector)
 
     assert result == 0
+
+
+def test_symmetry():
+    vector_1 = np.array([1, 0, 1, 0, 1, 0, 1, 0], dtype=np.uint8)
+    vector_2 = np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.uint8)
+
+    result_1 = hamming_distance(query=vector_1, candidate=vector_2)
+    result_2 = hamming_distance(query=vector_2, candidate=vector_1)
+
+    assert result_1 == result_2

--- a/tests/metrics/test_hamming.py
+++ b/tests/metrics/test_hamming.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+from image_recommender.metrics.hamming import hamming_distance
+
+
+def test_self_distance():
+    vector = np.array([1, 0, 1, 0, 1, 0, 1, 0], dtype=np.uint8)
+    result = hamming_distance(query=vector, candidate=vector)
+
+    assert result == 0

--- a/tests/metrics/test_hamming.py
+++ b/tests/metrics/test_hamming.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from image_recommender.metrics.hamming import hamming_distance
+from image_recommender.metrics.hamming import hamming_distance, hamming_distance_to_many
 
 
 def test_self_distance():
@@ -18,3 +18,23 @@ def test_symmetry():
     result_2 = hamming_distance(query=vector_2, candidate=vector_1)
 
     assert result_1 == result_2
+
+
+def test_vectorized_matches_scalar():
+    vector_1 = np.array([1, 0, 1, 0, 1, 0, 1, 0], dtype=np.uint8)
+    vector_2 = np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.uint8)
+    vector_3 = np.array([0, 0, 0, 0, 0, 0, 0, 0], dtype=np.uint8)
+    vector_4 = np.array([0, 1, 0, 1, 0, 1, 0, 1], dtype=np.uint8)
+
+    vectors = np.asarray([vector_2, vector_3, vector_4])
+
+    # calculate hamming distance pair by pair
+    s_result = []
+    for v in vectors:
+        s_result.append(hamming_distance(query=vector_1, candidate=v))
+    s_result = np.asarray(s_result)
+
+    # calculate hamming distance for all pairs at once
+    v_result = hamming_distance_to_many(query=vector_1, candidates=vectors)
+
+    assert np.array_equal(s_result, v_result)

--- a/tests/metrics/test_hamming.py
+++ b/tests/metrics/test_hamming.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from image_recommender.metrics.hamming import hamming_distance, hamming_distance_to_many
 
@@ -51,3 +52,18 @@ def test_vectorized_output_shape():
     result = hamming_distance_to_many(query=vector_1, candidates=vectors)
 
     assert result.shape == (3,)
+
+
+def test_dimensionality_mismatch():
+    vector_1 = np.array([1, 0, 1, 0, 1, 0, 1, 0, 1], dtype=np.uint8)
+    vector_2 = np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.uint8)
+
+    vector_3 = np.array([0, 0, 0, 0, 0, 0, 0], dtype=np.uint8)
+    vector_4 = np.array([0, 1, 0, 1, 0, 1, 0], dtype=np.uint8)
+    vectors = np.asarray([vector_3, vector_4])
+
+    with pytest.raises(ValueError):
+        hamming_distance(query=vector_1, candidate=vector_2)
+
+    with pytest.raises(ValueError):
+        hamming_distance_to_many(query=vector_1, candidates=vectors)


### PR DESCRIPTION
## Linked Issue
<!-- REQUIRED: link the primary issue (e.g. "Closes #123") -->
Closes #58 

## Summary (Delta vs Issue)
<!-- What changed compared to the issue plan? If exactly as planned, say "Matches issue." -->
Matches issue.

## Scope
<!-- Short bullets of what this PR actually changes/adds. No future work. -->
- Implement scalar and vectorized hamming distance (hamming_distance, hamming_distance_to_many) for pHash vectors
- Add dimensionality validation for both
- Add unit tests for scalar properties and vectorized behavior

## How Tested / Evidence
<!-- What proves it works? Paste commands & outcomes; attach logs/screens if useful. -->
-  pytest - 5 passed in 0.17s
- Scalar function: self-distance = 0 and symmetry
- Vectorized implementation matches scalar results and returns correct (N,) output shape
- Dimensionality mismatches raise ValueError

- Notes:
  - Metric operates directly on uint8 binary vectors and uses numpy broadcasting for efficiency

## Risk & Rollback (optional)
<!-- Any side effects? How to revert safely if needed. -->

## Notes for Reviewers (optional)
<!-- Call out tricky parts, follow-up PRs, or decisions deviating from the issue. -->

## Checklist
- [x] Labels set (area, block, priority)
- [ ] CI passes (lint-format, tests, cli-smoke)
- [x] Tests updated/added (only for what this PR changes)
