### PR TITLE
Feature/issue 92/profiling and bottleneck analysis

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - matplotlib
   - plotly
   - dash
+  - pandas
 
   # testing
   - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ name = "image-recommender"
 version = "0.0.1"
 requires-python = ">=3.12"
 # runtime deps
-dependencies = ["numpy", "pillow", "tqdm", "opencv-python", "torch", "torchvision", "annoy", "umap-learn", "matplotlib", "scikit-learn", "plotly", "dash"]
+dependencies = ["numpy", "pillow", "tqdm", "opencv-python", "torch", "torchvision", "annoy", "umap-learn", "matplotlib", "scikit-learn", "plotly", "dash", "pandas"]
 
 [project.optional-dependencies]
 # test deps

--- a/src/image_recommender/cli/commands.py
+++ b/src/image_recommender/cli/commands.py
@@ -14,6 +14,11 @@ from image_recommender.features.phash import extract_phashes
 from image_recommender.features.samples_driver_hsv import topk_on_samples
 from image_recommender.io.display import display_results
 from image_recommender.io.resolver import resolve_id_to_path
+from image_recommender.profiling.prof_benchmark import run_single_image_query_benchmark
+from image_recommender.profiling.prof_runner import (
+    print_profile_insights,
+    run_query_profiling,
+)
 from image_recommender.recommender.multi_image_query import multi_image_query
 from image_recommender.recommender.single_image_query import single_image_query
 from image_recommender.util.sampler import list_samples
@@ -264,3 +269,23 @@ def handle_query(args):
     except ValueError as e:
         print(f"Query failed: {e}")
         return 1
+
+
+def handle_profile_query(args) -> int:
+    """
+    Handles the "profile-query" CLI command.
+    """
+    if not args.image_path:
+        raise ValueError("--image-path is required for profiling!")
+
+    _, __, stats_path, png_path = run_query_profiling(
+        func=run_single_image_query_benchmark,
+        query_path=Path(args.image_path),
+        run_dir=Path(args.run_dir),
+    )
+
+    if args.verbose:
+        print_profile_insights(stats_path)
+
+    print(f"Saved profiling plot to: {png_path}")
+    return 0

--- a/src/image_recommender/cli/commands.py
+++ b/src/image_recommender/cli/commands.py
@@ -14,7 +14,10 @@ from image_recommender.features.phash import extract_phashes
 from image_recommender.features.samples_driver_hsv import topk_on_samples
 from image_recommender.io.display import display_results
 from image_recommender.io.resolver import resolve_id_to_path
-from image_recommender.profiling.prof_benchmark import run_single_image_query_benchmark
+from image_recommender.profiling.prof_benchmark import (
+    run_multi_image_query_benchmark,
+    run_single_image_query_benchmark,
+)
 from image_recommender.profiling.prof_runner import (
     print_profile_insights,
     run_query_profiling,
@@ -275,14 +278,31 @@ def handle_profile_query(args) -> int:
     """
     Handles the "profile-query" CLI command.
     """
-    if not args.image_path:
-        raise ValueError("--image-path is required for profiling!")
 
-    _, __, stats_path, png_path = run_query_profiling(
-        func=run_single_image_query_benchmark,
-        query_path=Path(args.image_path),
-        run_dir=Path(args.run_dir),
-    )
+    mode = args.mode
+
+    if mode == "single":
+        if not args.image_path:
+            raise ValueError("single mode requires --image-path")
+
+        _, __, stats_path, png_path = run_query_profiling(
+            func=run_single_image_query_benchmark,
+            query_path=Path(args.image_path),
+            run_dir=Path(args.run_dir),
+        )
+
+    elif mode == "multi":
+        if not args.image_paths:
+            raise ValueError("multi mode requires --image-paths")
+
+        _, __, stats_path, png_path = run_query_profiling(
+            func=run_multi_image_query_benchmark,
+            query_paths=[Path(p) for p in args.image_paths],
+            run_dir=Path(args.run_dir),
+        )
+
+    else:
+        raise ValueError(f"Unknown profiling mode: {mode}")
 
     if args.verbose:
         print_profile_insights(stats_path)

--- a/src/image_recommender/cli/commands.py
+++ b/src/image_recommender/cli/commands.py
@@ -280,6 +280,7 @@ def handle_profile_query(args) -> int:
     """
 
     mode = args.mode
+    output_dir = Path(args.output_dir)
 
     if mode == "single":
         if not args.image_path:
@@ -289,6 +290,7 @@ def handle_profile_query(args) -> int:
             func=run_single_image_query_benchmark,
             query_path=Path(args.image_path),
             run_dir=Path(args.run_dir),
+            output_dir=output_dir,
         )
 
     elif mode == "multi":
@@ -299,6 +301,7 @@ def handle_profile_query(args) -> int:
             func=run_multi_image_query_benchmark,
             query_paths=[Path(p) for p in args.image_paths],
             run_dir=Path(args.run_dir),
+            output_dir=output_dir,
         )
 
     else:

--- a/src/image_recommender/cli/main.py
+++ b/src/image_recommender/cli/main.py
@@ -260,14 +260,26 @@ def build_parser() -> ArgumentParser:
     # profile command
     cmd_profile = subparsers.add_parser(
         "profile-query",
-        help="Profile full image query pipeline",
-        description="Runs an image query with cProfile and outputs stats and bottleneck plot",
+        help="Profile full single-image query pipeline",
+        description="Runs single-image query with cProfile and outputs stats and bottleneck plot",
     )
     cmd_profile.set_defaults(run=handle_profile_query)
     cmd_profile.add_argument(
+        "--mode",
+        type=str,
+        required=True,
+        help="Profiling mode to run. Options: single | multi",
+    )
+    cmd_profile.add_argument(
         "--image-path",
         required=False,
-        help="Single image path",
+        help="Single image path (required for single mode)",
+    )
+    cmd_profile.add_argument(
+        "--image-paths",
+        nargs="+",
+        required=False,
+        help="Multiple image paths (required for multi mode)",
     )
     cmd_profile.add_argument(
         "--run-dir",

--- a/src/image_recommender/cli/main.py
+++ b/src/image_recommender/cli/main.py
@@ -16,6 +16,7 @@ from .commands import (
     handle_make_pilot,
     handle_map_embeddings,
     handle_phash_on_samples,
+    handle_profile_query,
     handle_query,
 )
 
@@ -254,6 +255,29 @@ def build_parser() -> ArgumentParser:
         action="store_true",
         default=False,
         help="Prints (path, score) pairs and opens corresponding images one by one.",
+    )
+
+    # profile command
+    cmd_profile = subparsers.add_parser(
+        "profile-query",
+        help="Profile full image query pipeline",
+        description="Runs an image query with cProfile and outputs stats and bottleneck plot",
+    )
+    cmd_profile.set_defaults(run=handle_profile_query)
+    cmd_profile.add_argument(
+        "--image-path",
+        required=False,
+        help="Single image path",
+    )
+    cmd_profile.add_argument(
+        "--run-dir",
+        required=True,
+        help="Directory containing feature folders",
+    )
+    cmd_profile.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print detailed profiling insights",
     )
 
     return parser

--- a/src/image_recommender/cli/main.py
+++ b/src/image_recommender/cli/main.py
@@ -287,6 +287,12 @@ def build_parser() -> ArgumentParser:
         help="Directory containing feature folders",
     )
     cmd_profile.add_argument(
+        "--output-dir",
+        type=str,
+        default="data/profiling",
+        help="Directory where profiling outputs are saved",
+    )
+    cmd_profile.add_argument(
         "--verbose",
         action="store_true",
         help="Print detailed profiling insights",

--- a/src/image_recommender/profiling/prof.py
+++ b/src/image_recommender/profiling/prof.py
@@ -1,0 +1,30 @@
+import cProfile
+import pstats
+from pathlib import Path
+
+
+def run_profile(output_path: Path, func, *args, **kwargs):
+    """
+    Profiles a function and writes stats to file.
+    """
+    profiler = cProfile.Profile()
+    profiler.enable()
+
+    result = func(*args, **kwargs)
+
+    profiler.disable()
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    profiler.dump_stats(str(output_path))
+
+    return output_path, result
+
+
+def load_stats(stats_path: Path, top_n: int = 10):
+    """
+    Loads pstats for further processing.
+    """
+    stats = pstats.Stats(str(stats_path))
+    stats.sort_stats("cumulative")
+    stats.print_stats(top_n)
+    return stats

--- a/src/image_recommender/profiling/prof_benchmark.py
+++ b/src/image_recommender/profiling/prof_benchmark.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from image_recommender.recommender.single_image_query import single_image_query
+
+
+def run_single_image_query_benchmark(query_path: Path, run_dir: Path) -> None:
+    """
+    Runs a benchmark for single image query.
+    """
+    single_image_query(
+        query_path=query_path,
+        run_dir=run_dir,
+        k=5,
+        feature_types=None,
+        weights=None,
+    )

--- a/src/image_recommender/profiling/prof_benchmark.py
+++ b/src/image_recommender/profiling/prof_benchmark.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from image_recommender.recommender.multi_image_query import multi_image_query
 from image_recommender.recommender.single_image_query import single_image_query
 
 
@@ -9,6 +10,20 @@ def run_single_image_query_benchmark(query_path: Path, run_dir: Path) -> None:
     """
     single_image_query(
         query_path=query_path,
+        run_dir=run_dir,
+        k=5,
+        feature_types=None,
+        weights=None,
+    )
+
+
+def run_multi_image_query_benchmark(query_paths: list[Path], run_dir: Path) -> None:
+    """
+    Runs a benchmark for multi image query.
+    """
+
+    multi_image_query(
+        query_paths=query_paths,
         run_dir=run_dir,
         k=5,
         feature_types=None,

--- a/src/image_recommender/profiling/prof_runner.py
+++ b/src/image_recommender/profiling/prof_runner.py
@@ -8,13 +8,15 @@ from image_recommender.profiling.prof_viz import (
 )
 
 
-def run_query_profiling(func, *args, top_n: int = 10, **kwargs):
+def run_query_profiling(func, *args, output_dir: Path, top_n: int = 10, **kwargs):
     """
     Profiles a function and writes stats and plot.
     """
 
-    stats_path = Path("data/profiling/profile.stats")
-    png_path = Path("data/profiling/bottlenecks.png")
+    output_dir = Path(output_dir)
+
+    stats_path = output_dir / "profile.stats"
+    png_path = output_dir / "bottlenecks.png"
 
     run_profile(
         stats_path,

--- a/src/image_recommender/profiling/prof_runner.py
+++ b/src/image_recommender/profiling/prof_runner.py
@@ -1,0 +1,54 @@
+import pstats
+from pathlib import Path
+
+from image_recommender.profiling.prof import load_stats, run_profile
+from image_recommender.profiling.prof_viz import (
+    plot_top_bottlenecks,
+    pstats_to_dataframe,
+)
+
+
+def run_query_profiling(func, *args, top_n: int = 10, **kwargs):
+    """
+    Profiles a function and writes stats and plot.
+    """
+
+    stats_path = Path("data/profiling/profile.stats")
+    png_path = Path("data/profiling/bottlenecks.png")
+
+    run_profile(
+        stats_path,
+        func,
+        *args,
+        **kwargs,
+    )
+
+    stats = load_stats(stats_path, top_n=top_n)
+    df = pstats_to_dataframe(stats)
+
+    plot_top_bottlenecks(df, png_path)
+
+    return df, stats, stats_path, png_path
+
+
+def print_profile_insights(stats_path: Path, project_filter: str | None = "image_recommender"):
+    """
+    Prints insights from pstats to console.
+    """
+
+    stats = pstats.Stats(str(stats_path))
+    stats.strip_dirs()
+    stats.sort_stats("cumulative")
+
+    print("\n=== TOP PROJECT HOTSPOTS ===")
+
+    if project_filter:
+        stats.print_stats(project_filter, 30)
+    else:
+        stats.print_stats(30)
+
+    print("\n=== WHO CALLS torch.serialization ===")
+    stats.print_callers("torch.serialization", 30)  # PyTorch serialization hotspot
+
+    print("\n=== WHO CALLS persistent_load ===")
+    stats.print_callers("persistent_load", 30)  # Model loading / deserialization hotspot

--- a/src/image_recommender/profiling/prof_viz.py
+++ b/src/image_recommender/profiling/prof_viz.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+def pstats_to_dataframe(stats, project_filter="image_recommender"):
+    """
+    Converts pstats to a DataFrame for analysis and visualization.
+    """
+
+    records = []
+
+    for func, (_, nc, tt, ct, _) in stats.stats.items():
+        filename = func[0]
+        func_name = func[2]
+
+        if project_filter is not None and project_filter not in filename:
+            continue
+
+        records.append(
+            {
+                "file": filename,
+                "function": func_name,
+                "label": f"{Path(filename).name}:{func_name}",
+                "ncalls": nc,
+                "tottime": tt,
+                "cumtime": ct,
+            }
+        )
+
+    df = pd.DataFrame(records)
+
+    if len(df) == 0:
+        return df
+
+    return df.sort_values("cumtime", ascending=False)
+
+
+def _interpolate_color(value, min_v, max_v):
+    """
+    Interpolates color between green (fast) and red (slow).
+    """
+
+    green = (28, 160, 68)
+    red = (220, 0, 85)
+
+    if max_v == min_v:
+        t = 0
+    else:
+        t = (value - min_v) / (max_v - min_v)
+
+    r = int(green[0] + t * (red[0] - green[0]))
+    g = int(green[1] + t * (red[1] - green[1]))
+    b = int(green[2] + t * (red[2] - green[2]))
+
+    return (r / 255, g / 255, b / 255)
+
+
+def plot_top_bottlenecks(df, output_path: Path, top_n=20):
+    """
+    Plots the top bottlenecks from the profiling data.
+    """
+
+    if df.empty:
+        print("No profiling data found.")
+        return
+
+    df = df.head(top_n).copy()
+    df = df.sort_values("cumtime", ascending=True)
+
+    min_v = df["cumtime"].min()
+    max_v = df["cumtime"].max()
+
+    colors = [_interpolate_color(v, min_v, max_v) for v in df["cumtime"]]
+
+    plt.figure(figsize=(12, 6))
+
+    bars = plt.barh(df["label"], df["cumtime"], color=colors)
+
+    for bar, value in zip(bars, df["cumtime"], strict=False):
+        plt.text(
+            bar.get_width() + (max_v * 0.01),  # small offset to the right of the bar
+            bar.get_y() + bar.get_height() / 2,
+            f"{value * 1000:.1f} ms",
+            va="center",
+            ha="left",
+            fontsize=8,
+        )
+
+    plt.xlabel("Cumulative Time (s)")
+    plt.title("Profiling Bottlenecks")
+
+    plt.tight_layout()
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    plt.savefig(output_path, dpi=150)
+    plt.close()

--- a/src/image_recommender/profiling/prof_viz.py
+++ b/src/image_recommender/profiling/prof_viz.py
@@ -1,10 +1,11 @@
 from pathlib import Path
 
 import matplotlib.pyplot as plt
-import pandas as pd
 
 
 def pstats_to_dataframe(stats, project_filter="image_recommender"):
+    import pandas as pd
+
     """
     Converts pstats to a DataFrame for analysis and visualization.
     """

--- a/tests/profiling/test_prof_runner.py
+++ b/tests/profiling/test_prof_runner.py
@@ -40,8 +40,15 @@ def _multi_args(tmp_path, run_dir, imgs):
 
 def _assert_outputs(tmp_path):
     out = tmp_path / "profiling"
-    assert (out / "profile.stats").exists()
-    assert (out / "bottlenecks.png").exists()
+
+    stats = out / "profile.stats"
+    png = out / "bottlenecks.png"
+
+    assert stats.exists()
+    assert png.exists()
+
+    assert stats.stat().st_size > 0
+    assert png.stat().st_size > 0
 
 
 def test_cli_single_smoke(tmp_path, samples):

--- a/tests/profiling/test_prof_runner.py
+++ b/tests/profiling/test_prof_runner.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+
+import pytest
+
+from image_recommender.cli.commands import handle_profile_query
+from image_recommender.config import SAMPLES_DIR
+
+
+@pytest.fixture(scope="session")
+def samples():
+    return [
+        p
+        for p in SAMPLES_DIR.iterdir()
+        if p.is_file() and p.suffix.lower() in {".jpg", ".jpeg", ".png"}
+    ]
+
+
+def _base_args(tmp_path, run_dir, mode, verbose=False):
+    return SimpleNamespace(
+        mode=mode,
+        image_path=None,
+        image_paths=None,
+        run_dir=str(run_dir),
+        output_dir=str(tmp_path / "profiling"),
+        verbose=verbose,
+    )
+
+
+def _single_args(tmp_path, run_dir, img, verbose=False):
+    args = _base_args(tmp_path, run_dir, "single", verbose)
+    args.image_path = str(img)
+    return args
+
+
+def _multi_args(tmp_path, run_dir, imgs):
+    args = _base_args(tmp_path, run_dir, "multi")
+    args.image_paths = [str(p) for p in imgs]
+    return args
+
+
+def _assert_outputs(tmp_path):
+    out = tmp_path / "profiling"
+    assert (out / "profile.stats").exists()
+    assert (out / "bottlenecks.png").exists()
+
+
+def test_cli_single_smoke(tmp_path, samples):
+    """
+    Tests that the single image profiling CLI command runs without errors and produces outputs.
+    """
+    args = _single_args(tmp_path, SAMPLES_DIR, samples[0])
+    handle_profile_query(args)
+    _assert_outputs(tmp_path)
+
+
+def test_cli_multi_smoke(tmp_path, samples):
+    """
+    Tests that the multi image profiling CLI command runs without errors and produces outputs.
+    """
+    args = _multi_args(tmp_path, SAMPLES_DIR, samples[:3])
+    handle_profile_query(args)
+    _assert_outputs(tmp_path)
+
+
+def test_verbose_mode_no_crash(tmp_path, samples, capsys):
+    """
+    Tests that verbose mode prints insights without crashing.
+    """
+    args = _single_args(tmp_path, SAMPLES_DIR, samples[0], verbose=True)
+    handle_profile_query(args)
+
+    out = capsys.readouterr().out.lower()
+
+    assert "profiling" in out or "bottleneck" in out or "top" in out
+
+
+def test_invalid_inputs_raise():
+    """
+    Tests that invalid profiling modes raise ValueError.
+    """
+    args = SimpleNamespace(
+        mode="invalid",
+        image_path=None,
+        image_paths=None,
+        run_dir="dummy",
+        output_dir="dummy",
+        verbose=False,
+    )
+
+    with pytest.raises(ValueError):
+        handle_profile_query(args)


### PR DESCRIPTION
## Linked Issue
<!-- REQUIRED: link the primary issue (e.g. "Closes #123") -->
Closes #92

## Summary (Delta vs Issue)
Matches issue.

## Scope
- implement CLI profiling for image query pipeline (single + multi mode)
- add cProfile-based profiling wrapper for full query execution
- write profiling results to disk (profile.stats)
- generate bottleneck visualization using matplotlib
- add verbose mode with console profiling insights

## How Tested / Evidence
-  Tested with test/profiling/test_prof_runner.py
<pre> pytest -q tests/profiling/test_prof_runner.py --> Result: 4 passed in 17.09 s </pre>

## Risk & Rollback (optional)
<!-- Any side effects? How to revert safely if needed. -->

## Notes for Reviewers (optional)
<!-- Call out tricky parts, follow-up PRs, or decisions deviating from the issue. -->

## Checklist
- [x] Labels set (area, block, priority)
- [x] CI passes (lint-format, tests, cli-smoke)
- [x] Tests updated/added (only for what this PR changes)