### PR TITLE
validation/issue 95/full dataset validation

### DIFF
--- a/src/image_recommender/cli/commands.py
+++ b/src/image_recommender/cli/commands.py
@@ -16,6 +16,7 @@ from image_recommender.io.display import display_results
 from image_recommender.io.resolver import resolve_id_to_path
 from image_recommender.recommender.multi_image_query import multi_image_query
 from image_recommender.recommender.single_image_query import single_image_query
+from image_recommender.search.annoy import AnnoySearchBackend
 from image_recommender.util.sampler import list_samples
 from image_recommender.viz.explorer import run_embedding_explorer
 from image_recommender.viz.map_embeddings import run_map_embeddings
@@ -227,6 +228,15 @@ def handle_query(args):
         if backend == "annoy" and k_candidates is None:
             raise ValueError("k-candidates must be provided when using annoy backend")
 
+        annoy_backend = None
+
+        if backend == "annoy":
+            annoy_backend = AnnoySearchBackend(
+                run_dir=Path(args.run_dir),
+                feature_type="embedding",
+                k=k_candidates,
+            )
+
         # for one query
         if len(query_paths) == 1:
             top_k, used_features = single_image_query(
@@ -236,6 +246,7 @@ def handle_query(args):
                 feature_types=args.feature_types,
                 backend=backend,
                 k_candidates=k_candidates,
+                annoy_backend=annoy_backend,
             )
 
         # for multiple queries
@@ -247,6 +258,7 @@ def handle_query(args):
                 feature_types=args.feature_types,
                 backend=backend,
                 k_candidates=k_candidates,
+                annoy_backend=annoy_backend,
             )
 
         # ensure requested features were used for query

--- a/src/image_recommender/cli/commands.py
+++ b/src/image_recommender/cli/commands.py
@@ -257,7 +257,7 @@ def handle_query(args):
                 )
 
         # resolve (id, score) -> (filepath, score)
-        top_k_resolved = resolve_id_to_path(top_k=top_k)
+        top_k_resolved = resolve_id_to_path(top_k=top_k, run_dir=args.run_dir)
 
         if args.display:
             # call display function

--- a/src/image_recommender/io/resolver.py
+++ b/src/image_recommender/io/resolver.py
@@ -6,7 +6,7 @@ from image_recommender.db.connector import get_path_by_id
 
 def resolve_id_to_path(
     top_k: list[tuple[int, float]],
-    run_dir: Path | str,
+    run_dir: Path | str = "data/samples",
 ) -> list[tuple[Path, float]]:
     """
     Resolves (id, score) pairs to (path, score).

--- a/src/image_recommender/io/resolver.py
+++ b/src/image_recommender/io/resolver.py
@@ -1,12 +1,13 @@
 import json
 from pathlib import Path
 
+from image_recommender.config import SAMPLES_DIR
 from image_recommender.db.connector import get_path_by_id
 
 
 def resolve_id_to_path(
     top_k: list[tuple[int, float]],
-    run_dir: Path | str = "data/samples",
+    run_dir: Path | str = SAMPLES_DIR,
 ) -> list[tuple[Path, float]]:
     """
     Resolves (id, score) pairs to (path, score).
@@ -18,7 +19,7 @@ def resolve_id_to_path(
     run_dir = Path(run_dir)
 
     # samples mode
-    if run_dir == Path("data/samples"):
+    if run_dir == SAMPLES_DIR:
         samples_dir = run_dir
         mapping_path = samples_dir / "id_to_filename.json"
 

--- a/src/image_recommender/io/resolver.py
+++ b/src/image_recommender/io/resolver.py
@@ -1,46 +1,59 @@
 import json
 from pathlib import Path
 
+from image_recommender.db.connector import get_path_by_id
 
-def resolve_id_to_path(top_k: list[tuple[int, float]]) -> list[tuple[Path, float]]:
+
+def resolve_id_to_path(
+    top_k: list[tuple[int, float]],
+    run_dir: Path | str,
+) -> list[tuple[Path, float]]:
     """
-    Resolves query results from (id, score) pairs to (path, score) pairs using samples id to filename mapping.
+    Resolves (id, score) pairs to (path, score).
 
-    Input:
-        top_k: List of (image_id, score) pairs returned by query pipeline
-
-    Output:
-        List of (image_path, score) pairs in same order as input
-
-    Raises:
-        ValueError: If an image_id is not found in the mapping
+    Uses:
+        - Samples mapping if run_dir == data/samples
+        - DB resolver otherwise
     """
-    # build mapping path
-    samples_dir = Path("data/samples")
-    mapping_path = samples_dir / "id_to_filename.json"
+    run_dir = Path(run_dir)
 
+    # samples mode
+    if run_dir == Path("data/samples"):
+        samples_dir = run_dir
+        mapping_path = samples_dir / "id_to_filename.json"
+
+        with open(mapping_path) as f:
+            mapping = json.load(f)
+
+        mapping = {int(k): v for k, v in mapping.items()}
+
+        top_k_resolved = []
+
+        for image_id, score in top_k:
+            try:
+                filename = mapping[image_id]
+            except KeyError as e:
+                raise ValueError(f"Id {image_id} not found in samples mapping") from e
+
+            filepath = samples_dir / filename
+            top_k_resolved.append((filepath, score))
+
+        return top_k_resolved
+
+    # full dataset mode
     top_k_resolved = []
 
-    # load mapping
-    with open(mapping_path) as f:
-        mapping = json.load(f)
-
-    # normalize (keys -> int)
-    mapping = {int(k): v for k, v in mapping.items()}
-
     for image_id, score in top_k:
-
-        # map filename to id
         try:
-            filename = mapping[image_id]
+            path_str = get_path_by_id(image_id)
+        except Exception as e:
+            raise ValueError(f"Id {image_id} could not be resolved via DB") from e
 
-        except KeyError as e:
-            raise ValueError(f"Id {image_id} not found in mapping") from e
+        filepath = Path(path_str)
 
-        # append path prefix
-        filepath = samples_dir / filename
+        if not filepath.exists():
+            raise ValueError(f"Resolved path does not exist: {filepath}")
 
-        # build tuples
         top_k_resolved.append((filepath, score))
 
     return top_k_resolved

--- a/src/image_recommender/recommender/multi_image_query.py
+++ b/src/image_recommender/recommender/multi_image_query.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import numpy as np
 
 from image_recommender.recommender.single_image_query import _compute_full_scores
+from image_recommender.search.annoy import AnnoySearchBackend
 from image_recommender.util.logs import get_logger
 
 logger = get_logger(__name__)
@@ -16,6 +17,7 @@ def multi_image_query(
     weights: dict[str, float] | None = None,
     backend: str = "linear",
     k_candidates: int | None = None,
+    annoy_backend: AnnoySearchBackend | None = None,
 ) -> tuple[list[tuple[int, float]], set[str]]:
     """
     Runs a multi image query by aggregating aligned per query score arrays via mean.
@@ -52,6 +54,7 @@ def multi_image_query(
         weights=weights,
         backend=backend,
         k_candidates=k_candidates,
+        annoy_backend=annoy_backend,
     )
 
     score_arrays = [score_arr]
@@ -69,6 +72,7 @@ def multi_image_query(
             weights=weights,
             backend=backend,
             k_candidates=k_candidates,
+            annoy_backend=annoy_backend,
             subset_ids=reference_ids if backend == "annoy" else None,
         )
 

--- a/src/image_recommender/recommender/query_helpers.py
+++ b/src/image_recommender/recommender/query_helpers.py
@@ -195,7 +195,7 @@ def distances_all_features_subset(
     queries_by_feature: dict[str, np.ndarray],
     subset_ids: list[int],
     feature_types: list[str] | None = None,
-) -> dict[str, np.ndarray]:
+) -> tuple[dict[str, np.ndarray], list[int]]:
     """
     Computes distances from a single query to a subset of candidate ids for all available feature types.
 
@@ -207,6 +207,7 @@ def distances_all_features_subset(
 
     Output:
         {feature_type: distances (k,)} aligned to subset_ids order
+        shared subset: List of remaining (usable) candidate ids
 
     Raises:
         ValueError: If no valid features are available or subset ids are inconsistent
@@ -226,9 +227,8 @@ def distances_all_features_subset(
 
     if feature_types is None:
         features_to_process = available_features
-
-    # only keep requested features
     else:
+        # only keep requested features
         features_to_process = set(feature_types) & available_features
 
     if not features_to_process:
@@ -242,8 +242,10 @@ def distances_all_features_subset(
     }
 
     dist_dict = {}  # dict[str, np.ndarray]
+    valid_ids_per_feature = {}  # collect valid ids per feature
+    id_to_vec_per_feature = {}  # store mappings for reuse
 
-    # for each feature
+    # Step 1: collect valid ids & mappings
     for feature in sorted(features_to_process):
 
         # load all vectors and ids
@@ -265,16 +267,34 @@ def distances_all_features_subset(
             )
 
             # build id to vector mapping
-            for id_, vec in zip(ids, features, strict=True):  # pair -> (id, vector), ...
-                id_to_vec[id_] = vec  # key-value pair -> {id: vector , ...}
+            for id_, vec in zip(ids, features, strict=True):
+                id_to_vec[id_] = vec
 
-        # ensure all subset ids exist
-        missing_ids = [id_ for id_ in subset_ids if id_ not in id_to_vec]
-        if missing_ids:
-            raise ValueError(f"Missing {len(missing_ids)} ids in feature '{feature}' subset")
+        # determine valid ids for current feature
+        valid_ids = [id_ for id_ in subset_ids if id_ in id_to_vec]
+
+        if not valid_ids:
+            raise ValueError(f"No valid ids left for feature '{feature}'")
+
+        valid_ids_per_feature[feature] = set(valid_ids)
+        id_to_vec_per_feature[feature] = id_to_vec
+
+    # Step 2: compute shared subset
+    shared_ids = set.intersection(*valid_ids_per_feature.values())
+
+    if not shared_ids:
+        raise ValueError("No common ids across features after filtering")
+
+    # preserve original order
+    shared_subset_ids = [id_ for id_ in subset_ids if id_ in shared_ids]
+
+    # Step 3: compute distances on shared subset
+    for feature in sorted(features_to_process):
+
+        id_to_vec = id_to_vec_per_feature[feature]
 
         # build subset matrix in canonical order
-        subset_matrix = np.vstack([id_to_vec[id_] for id_ in subset_ids])
+        subset_matrix = np.vstack([id_to_vec[id_] for id_ in shared_subset_ids])
 
         # compute distances
         query = queries_by_feature[feature]
@@ -285,7 +305,7 @@ def distances_all_features_subset(
         # assign distances for current feature to final distance dict
         dist_dict[feature] = distances.astype(np.float32)
 
-    return dist_dict
+    return dist_dict, shared_subset_ids
 
 
 def get_score_arr(

--- a/src/image_recommender/recommender/single_image_query.py
+++ b/src/image_recommender/recommender/single_image_query.py
@@ -57,19 +57,18 @@ def _compute_full_scores(
             k=k_candidates,
         )
 
+        # determine candidate subset
         if subset_ids is None:
-            # generate candidate subset via annoy
             subset_ids_arr, _ = annoy_backend.search(query_embedding)
-            canonical_ids = subset_ids_arr.tolist()
+            candidate_ids = subset_ids_arr.tolist()
         else:
-            # reuse provided subset
-            canonical_ids = subset_ids
+            candidate_ids = subset_ids
 
-        # compute distances only for subset
-        dist_dict = distances_all_features_subset(
+        # compute distances and get aligned canonical ids
+        dist_dict, canonical_ids = distances_all_features_subset(
             run_dir=run_dir,
             queries_by_feature=queries_by_feature,
-            subset_ids=canonical_ids,
+            subset_ids=candidate_ids,
             feature_types=feature_types,
         )
 

--- a/src/image_recommender/recommender/single_image_query.py
+++ b/src/image_recommender/recommender/single_image_query.py
@@ -24,6 +24,7 @@ def _compute_full_scores(
     backend: str = "linear",
     k_candidates: int | None = None,
     subset_ids: list[int] | None = None,
+    annoy_backend: AnnoySearchBackend | None = None,
 ) -> tuple[np.ndarray, list[int], set[str]]:
     """
     Internal helper to compute full aligned score array for a single query.
@@ -51,11 +52,12 @@ def _compute_full_scores(
         query_embedding = queries_by_feature["embedding"]
 
         # run annoy to get candidate subset
-        annoy_backend = AnnoySearchBackend(
-            run_dir=run_dir,
-            feature_type="embedding",
-            k=k_candidates,
-        )
+        if annoy_backend is None:
+            annoy_backend = AnnoySearchBackend(
+                run_dir=run_dir,
+                feature_type="embedding",
+                k=k_candidates,
+            )
 
         # determine candidate subset
         if subset_ids is None:
@@ -114,6 +116,7 @@ def single_image_query(
     weights: dict[str, float] | None = None,
     backend: str = "linear",
     k_candidates: int | None = None,
+    annoy_backend: AnnoySearchBackend | None = None,
 ) -> tuple[list[tuple[int, float]], set[str]]:
     """
     Runs a single image query and returns the top k most similar results, as well as used feature types.
@@ -149,6 +152,7 @@ def single_image_query(
         weights=weights,
         backend=backend,
         k_candidates=k_candidates,
+        annoy_backend=annoy_backend,
     )
 
     # rank via indices (lowest -> highest)


### PR DESCRIPTION
## Linked Issue
<!-- REQUIRED: link the primary issue (e.g. "Closes #123") -->
Closes #95 

## Summary (Delta vs Issue)
<!-- What changed compared to the issue plan? If exactly as planned, say "Matches issue." -->
Mostly matches issue.
Resolver adjusted to support both sample and db modes.

## Scope
<!-- Short bullets of what this PR actually changes/adds. No future work. -->
- Enable full dataset query execution via db backed id resolution
- Add dual resolver (samples vs db) without breaking existing tests
- Ensure robust subset alignment across features (handles missing vectors)
- Integrate annoy backend into single and multi image query paths
- Reuse annoy backend within cli call to avoid redundant index loading

## How Tested / Evidence
<!-- What proves it works? Paste commands & outcomes; attach logs/screens if useful. -->
-  Verified single image query on full dataset (linear + annoy)
- Verified deterministic results across repeated runs
- Verified multi image query behavior (linear + annoy)
- Verified resolver returns valid paths (including self match at rank 1)
- Verified display mode works without errors

- Notes:
  - Annoy integration works correctly but does not yet reduce runtime due to full shard loading
  - Multi image annoy shows expected subset bias behavior

## Risk & Rollback (optional)
<!-- Any side effects? How to revert safely if needed. -->

## Notes for Reviewers (optional)
<!-- Call out tricky parts, follow-up PRs, or decisions deviating from the issue. -->

## Checklist
- [x] Labels set (area, block, priority)
- [x] CI passes (lint-format, tests, cli-smoke)
- [x] Tests updated/added (only for what this PR changes)
